### PR TITLE
Fix fallback handling in DataUtils.getFieldValue

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -291,7 +291,12 @@ const DataUtils = {
             }
         }
         
-        return fallback || CONFIG.FALLBACK_VALUES[fieldMapping] || 'N/A';
+        // Usar el valor de fallback incluso si es una cadena vacía
+        if (fallback !== undefined) {
+            return fallback;
+        }
+
+        return CONFIG.FALLBACK_VALUES[fieldMapping] || 'N/A';
     },
 
     /**


### PR DESCRIPTION
## Summary
- ensure `DataUtils.getFieldValue` returns provided fallback even if empty string

## Testing
- `node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const sandbox = { window:{}, document:{addEventListener:()=>{}, body:{appendChild:()=>{}, removeChild:()=>{}}}, console };
vm.runInNewContext(fs.readFileSync('js/config.js','utf8'), sandbox);
vm.runInNewContext(fs.readFileSync('js/utils.js','utf8'), sandbox);
console.log('with empty fallback', sandbox.window.DataUtils.getFieldValue({}, 'component', ''));
console.log('with default fallback', sandbox.window.DataUtils.getFieldValue({}, 'component'));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68406fb9dc1c8330b1421de78176c29c