### PR TITLE
Add CSVParser test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # SIL
+
+## Running tests
+
+Run the CSV parser test with:
+
+```bash
+node tests/test-csv-parser.js
+```
+
+This requires only Node.js and will output `All tests passed.` when the parser works correctly.

--- a/tests/fixtures/sample.csv
+++ b/tests/fixtures/sample.csv
@@ -1,0 +1,3 @@
+Componente;Direccion;SectorE;Nombre_Indicador
+Comp1;Dir1;Sector1;Indicador con acento Ã¡
+Comp2;Dir2;Sector2;Indicador con eÃ±e Ã±

--- a/tests/test-csv-parser.js
+++ b/tests/test-csv-parser.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const assert = require('assert');
+
+// Minimal globals expected by csvParser.js
+global.window = {};
+// Provide only the fields used by CSVParser
+global.CONFIG = {
+  REQUIRED_COLUMNS: ['Componente', 'Direccion', 'SectorE'],
+  FALLBACK_VALUES: { indicatorName: 'Sin nombre' }
+};
+// Stub NotificationManager to avoid DOM usage
+global.NotificationManager = { show: () => {} };
+
+// Load the parser script which assigns CSVParser to window
+require('../js/csvParser.js');
+const CSVParser = global.window.CSVParser;
+
+const csv = fs.readFileSync(__dirname + '/fixtures/sample.csv', 'utf8');
+const records = CSVParser.parse(csv);
+
+assert(Array.isArray(records), 'parse should return an array');
+assert.strictEqual(records.length, 2, 'should return two records');
+assert.strictEqual(records[0].Nombre_Indicador, 'Indicador con acento á');
+assert.strictEqual(records[1].Nombre_Indicador, 'Indicador con eñe ñ');
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- add a fixture with misencoded characters
- add test for CSVParser using Node's `assert`
- show how to run the test in README

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_68407997492883308d454b4095f6b990