### PR TITLE
Add component color palette

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -196,3 +196,10 @@
     font-weight: 700;
     color: var(--primary-blue);
 }
+
+/* Component text color classes */
+.color-1 { color: #1f8fff; }
+.color-2 { color: #00bfff; }
+.color-3 { color: #89cfeb; }
+.color-4 { color: #add8e6; }
+.color-5 { color: #b1e0e7; }

--- a/css/variables.css
+++ b/css/variables.css
@@ -94,6 +94,13 @@
     --chart-color-4: #87ceeb;
     --chart-color-5: #a0c8e8;
     --chart-color-6: #b3d9ff;
+
+    /* Component Color Palette */
+    --color-1: #1f8fff;
+    --color-2: #00bfff;
+    --color-3: #89cfeb;
+    --color-4: #add8e6;
+    --color-5: #b1e0e7;
     
     /* Gradients */
     --gradient-primary: linear-gradient(135deg, var(--primary-blue) 0%, var(--secondary-blue) 100%);

--- a/js/config.js
+++ b/js/config.js
@@ -3,28 +3,13 @@ const CONFIG = {
     // Data Source
     CSV_PATH: 'data/indicators.csv',
     
-    // Chart Configuration - Paleta de azules y verdes
+    // Chart Configuration - Paleta de colores para componentes
     CHART_COLORS: [
-        '#1e4c72', // Azul oscuro (Primary Blue)
-        '#2d5aa0', // Azul medio (Secondary Blue) 
-        '#4a90c2', // Azul claro (Light Blue)
-        '#1565c0', // Azul material
-        '#1976d2', // Azul vibrante
-        '#42a5f5', // Azul cielo
-        '#2e7d32', // Verde oscuro
-        '#388e3c', // Verde medio
-        '#43a047', // Verde claro
-        '#4caf50', // Verde material
-        '#66bb6a', // Verde suave
-        '#81c784', // Verde pastel
-        '#00695c', // Verde azulado oscuro
-        '#00796b', // Verde azulado
-        '#26a69a', // Verde azulado claro
-        '#4db6ac', // Verde agua
-        '#0d47a1', // Azul marino
-        '#1e88e5', // Azul eléctrico
-        '#29b6f6', // Azul celeste
-        '#4fc3f7'  // Azul cielo claro
+        '#1f8fff',
+        '#00bfff',
+        '#89cfeb',
+        '#add8e6',
+        '#b1e0e7'
     ],
     
     // Colores específicos para periodicidad


### PR DESCRIPTION
## Summary
- define CHART_COLORS with new palette for components
- expose component color variables in css
- add CSS classes for component text colors

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_684086cf18d083309f21d84c7d877ec2