### PR TITLE
Add gradient header and province emblem

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -15,7 +15,7 @@ body {
 
 /* Header */
 .header {
-    background: linear-gradient(135deg, var(--primary-blue) 0%, var(--secondary-blue) 100%);
+    background: linear-gradient(90deg, var(--primary-blue) 0%, var(--color-5) 100%);
     color: var(--light-gray);
     padding: 1.5rem 0;
     box-shadow: var(--shadow);
@@ -46,6 +46,11 @@ body {
     display: flex;
     align-items: center;
     gap: 1rem;
+}
+
+.header-emblem {
+    height: 70px;
+    object-fit: contain;
 }
 
 .logo {

--- a/index.html
+++ b/index.html
@@ -33,9 +33,10 @@
                 <div>
                     <h1 class="color-1">Sistema de Información Local [SIL]</h1>
                     <div class="header-subtitle color-2">Dashboard de Indicadores</div>
-		    <div class="header-subtitle color-2">Gobierno Autónomo Descentralizado Provincial de Manabí</div>
+                    <div class="header-subtitle color-2">Gobierno Autónomo Descentralizado Provincial de Manabí</div>
                 </div>
             </div>
+            <img class="header-emblem" src="img/manabi.png" alt="Escudo de Manabí">
         </div>
     </header>
 


### PR DESCRIPTION
## Summary
- update header gradient to fade from primary blue to a pale tone
- add logo image at the right side of header

## Testing
- `node tests/test-csv-parser.js`


------
https://chatgpt.com/codex/tasks/task_e_6840f5064aec8330afceceb887c8192d