### PR TITLE
Improve header gradient

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -15,7 +15,7 @@ body {
 
 /* Header */
 .header {
-    background: linear-gradient(90deg, var(--primary-blue) 0%, var(--color-5) 100%);
+    background: linear-gradient(90deg, var(--primary-blue) 0%, var(--color-5-70) 100%);
     color: var(--light-gray);
     padding: 1.5rem 0;
     box-shadow: var(--shadow);
@@ -51,6 +51,8 @@ body {
 .header-emblem {
     height: 70px;
     object-fit: contain;
+    position: relative;
+    z-index: 1;
 }
 
 .logo {

--- a/css/variables.css
+++ b/css/variables.css
@@ -107,6 +107,7 @@
     --gradient-primary: linear-gradient(135deg, var(--primary-blue) 0%, var(--secondary-blue) 100%);
     --gradient-light: linear-gradient(135deg, var(--light-gray) 0%, var(--medium-gray) 100%);
     --gradient-accent: linear-gradient(90deg, var(--primary-blue), var(--light-blue));
+    --color-5-70: rgba(177, 224, 231, 0.7);
     
     /* Animation Timing */
     --animation-duration-fast: 0.15s;


### PR DESCRIPTION
## Summary
- adjust gradient of header so it fades to 70% opacity
- ensure header emblem displays above the background

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_6840f66dfb8c8330ba8cba2876ca2b1d