### PR TITLE
Fix header emblem position

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -40,6 +40,7 @@ body {
     justify-content: space-between;
     flex-wrap: wrap;
     gap: 1rem;
+    position: relative; /* permite posicionar elementos absolutamente */
 }
 
 .logo-section {
@@ -51,8 +52,10 @@ body {
 .header-emblem {
     height: 70px;
     object-fit: contain;
-    position: relative;
-    z-index: 1;
+    position: absolute; /* colocar sobre el listón */
+    top: -20px;
+    right: 2rem;
+    z-index: 101;
 }
 
 .logo {


### PR DESCRIPTION
## Summary
- move emblem image above the sticky header

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_6840f8c9aad083308c4ea4615987a860