### PR TITLE
Improve Buscar Indicador search logic

### DIFF
--- a/js/config.js
+++ b/js/config.js
@@ -41,7 +41,7 @@ const CONFIG = {
     
     // Performance Settings
     DEBOUNCE_DELAY: 300,
-    SEARCH_MIN_LENGTH: 2,
+    SEARCH_MIN_LENGTH: 4,
     MAX_CHART_ITEMS: 10,
     TABLE_PAGE_SIZE: 50,
     

--- a/js/filterManager.js
+++ b/js/filterManager.js
@@ -88,10 +88,16 @@ class FilterManager {
             }
         });
 
-        // Filtro de búsqueda con debounce
+        // Filtro de búsqueda con debounce y longitud mínima
         if (this.elements.search) {
             const debouncedSearch = PerformanceUtils.debounce(
-                (value) => this.handleFilterChange('search', value),
+                (value) => {
+                    if (value.length >= CONFIG.SEARCH_MIN_LENGTH) {
+                        this.handleFilterChange('search', value);
+                    } else if (value.length === 0) {
+                        this.handleFilterChange('search', '');
+                    }
+                },
                 CONFIG.DEBOUNCE_DELAY
             );
 


### PR DESCRIPTION
## Summary
- enforce minimum length of 4 characters before filtering
- debounce search with new behavior

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_6840fa7623c483308f79f58e5994a878