### PR TITLE
Move search controls inside indicators table

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -321,6 +321,12 @@ body {
     font-size: 0.9rem;
 }
 
+.table-search-section {
+    background: var(--light-gray);
+    padding: 1rem 2rem;
+    border-bottom: 2px solid var(--medium-gray);
+}
+
 .table-container {
     overflow-x: auto;
     max-height: 600px;
@@ -385,7 +391,7 @@ body {
         grid-template-columns: 1fr;
     }
 
-    .filters-section, .chart-card, .table-header {
+    .filters-section, .chart-card, .table-header, .table-search-section {
         padding: 1.5rem;
     }
 

--- a/index.html
+++ b/index.html
@@ -82,20 +82,6 @@
                     <div id="sector-help" class="sr-only">Selecciona un sector estadístico para filtrar los indicadores</div>
                 </div>
 
-                <div class="search-container">
-                    <label class="filter-label" for="search-input">Buscar Indicador</label>
-                    <div style="position: relative;">
-                        <i class="fas fa-search search-icon"></i>
-                        <input 
-                            type="text" 
-                            class="search-input" 
-                            id="search-input"
-                            placeholder="Escribe el nombre del indicador que buscas..."
-                            aria-describedby="search-help"
-                        >
-                    </div>
-                    <div id="search-help" class="sr-only">Escribe para buscar indicadores por nombre</div>
-                </div>
             </div>
         </section>
 
@@ -190,7 +176,24 @@
                     Explora todos los indicadores disponibles con información detallada
                 </div>
             </div>
-            
+
+            <div class="table-search-section">
+                <div class="search-container">
+                    <label class="filter-label" for="search-input">Buscar Indicador</label>
+                    <div style="position: relative;">
+                        <i class="fas fa-search search-icon"></i>
+                        <input
+                            type="text"
+                            class="search-input"
+                            id="search-input"
+                            placeholder="Escribe el nombre del indicador que buscas..."
+                            aria-describedby="search-help"
+                        >
+                    </div>
+                    <div id="search-help" class="sr-only">Escribe para buscar indicadores por nombre</div>
+                </div>
+            </div>
+
             <div class="table-container">
                 <table class="indicators-table" role="table" aria-labelledby="table-title">
                     <thead>

--- a/js/filterManager.js
+++ b/js/filterManager.js
@@ -384,22 +384,20 @@ class FilterManager {
      * Crea el elemento contador de resultados
      */
     createResultsCounter() {
-        const filtersSection = DOMUtils.safeQuerySelector('.filters-section');
-        if (!filtersSection) return null;
+        const searchSection = DOMUtils.safeQuerySelector('.table-search-section');
+        if (!searchSection) return null;
 
         const counter = document.createElement('div');
         counter.className = 'results-counter';
         counter.style.cssText = `
-            text-align: center;
+            text-align: right;
             font-size: 0.9rem;
             color: var(--dark-gray);
             opacity: 0.8;
-            margin-top: 1rem;
-            padding-top: 1rem;
-            border-top: 1px solid var(--medium-gray);
+            margin-top: 0.5rem;
         `;
 
-        filtersSection.appendChild(counter);
+        searchSection.appendChild(counter);
         return counter;
     }
 


### PR DESCRIPTION
## Summary
- relocate search bar and results counter into the indicators table
- style table search section
- adapt JS to place the results counter in the new location

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_6841079ba0a4833084fea8247e7c9d61