### PR TITLE
Fix header emblem position

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -53,9 +53,11 @@ body {
     height: 70px;
     object-fit: contain;
     position: absolute; /* colocar sobre el listón */
-    top: -20px;
+    top: 50%;
+    transform: translateY(-50%);
     right: 2rem;
     z-index: 101;
+    box-shadow: var(--shadow-light);
 }
 
 .logo {


### PR DESCRIPTION
## Summary
- center emblem vertically in the header
- add a subtle shadow to highlight the emblem

## Testing
- `node tests/test-csv-parser.js`


------
https://chatgpt.com/codex/tasks/task_e_68410992d3e88330bcf5a5da02816185