### PR TITLE
Add Dashboard column with link button

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -365,6 +365,22 @@ body {
     background: var(--light-gray);
 }
 
+/* Button for dashboard links */
+.dashboard-btn {
+    display: inline-block;
+    background-color: var(--pastel-purple);
+    color: var(--white);
+    padding: 0.4rem 0.8rem;
+    border-radius: var(--border-radius-small);
+    text-decoration: none;
+    font-weight: 600;
+    transition: var(--transition-fast);
+}
+
+.dashboard-btn:hover {
+    opacity: 0.85;
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
     .container {

--- a/css/variables.css
+++ b/css/variables.css
@@ -105,6 +105,8 @@
 
     /* Highlight */
     --highlight-orange: #ffe5b4;
+    /* Pastel purple used for dashboard links */
+    --pastel-purple: #b19cd9;
     
     /* Gradients */
     --gradient-primary: linear-gradient(135deg, var(--primary-blue) 0%, var(--secondary-blue) 100%);

--- a/index - copia.html
+++ b/index - copia.html
@@ -769,11 +769,12 @@
                             <th scope="col">Sector Estadístico</th>
                             <th scope="col">ID RA</th>
                             <th scope="col">Periodicidad</th>
+                            <th scope="col">Dashboard</th>
                         </tr>
                     </thead>
                     <tbody id="indicatorsTableBody">
                         <tr>
-                            <td colspan="6" class="empty-state">
+                            <td colspan="7" class="empty-state">
                                 <i class="fas fa-spinner fa-spin"></i>
                                 <p>Cargando indicadores...</p>
                             </td>
@@ -1043,7 +1044,7 @@
             if (data.length === 0) {
                 tableBody.innerHTML = `
                     <tr>
-                        <td colspan="6" class="empty-state">
+                        <td colspan="7" class="empty-state">
                             <i class="fas fa-search"></i>
                             <p>No se encontraron indicadores que coincidan con los filtros aplicados</p>
                         </td>
@@ -1318,7 +1319,7 @@
                 if (tableBody) {
                     tableBody.innerHTML = `
                         <tr>
-                            <td colspan="6" class="empty-state">
+                            <td colspan="7" class="empty-state">
                                 <i class="fas fa-exclamation-triangle" style="color: var(--danger);"></i>
                                 <p>Error al cargar los datos: ${error.message}</p>
                                 <p style="font-size: 0.8rem; margin-top: 0.5rem;">

--- a/index.html
+++ b/index.html
@@ -204,11 +204,12 @@
                             <th scope="col">Sector Estadístico</th>
                             <th scope="col">ID RA</th>
                             <th scope="col">Periodicidad</th>
+                            <th scope="col">Dashboard</th>
                         </tr>
                     </thead>
                     <tbody id="indicatorsTableBody">
                         <tr>
-                            <td colspan="6" class="empty-state">
+                            <td colspan="7" class="empty-state">
                                 <i class="fas fa-spinner fa-spin"></i>
                                 <p>Cargando indicadores...</p>
                             </td>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -504,6 +504,10 @@ class Dashboard {
             {
                 content: `<span class="badge badge-periodicity" style="background-color: ${periodicityColor};">${periodicity}</span>`,
                 isHTML: true
+            },
+            {
+                content: this.createDashboardLink(indicator.Dashboard),
+                isHTML: true
             }
         ];
 
@@ -553,6 +557,16 @@ class Dashboard {
     }
 
     /**
+     * Crea el enlace al dashboard si existe
+     */
+    createDashboardLink(url) {
+        if (url) {
+            return `<a href="${url}" class="dashboard-btn" target="_blank" rel="noopener">Ver</a>`;
+        }
+        return '';
+    }
+
+    /**
      * Resalta coincidencias de búsqueda
      */
     highlightSearchTerm(text, term) {
@@ -570,7 +584,7 @@ class Dashboard {
         if (tableBody) {
             tableBody.innerHTML = `
                 <tr>
-                    <td colspan="6" class="empty-state">
+                    <td colspan="7" class="empty-state">
                         <i class="fas fa-search"></i>
                         <p>No se encontraron indicadores que coincidan con los filtros aplicados</p>
                     </td>
@@ -587,7 +601,7 @@ class Dashboard {
         if (tableBody) {
             tableBody.innerHTML = `
                 <tr>
-                    <td colspan="6" class="empty-state">
+                    <td colspan="7" class="empty-state">
                         <i class="fas fa-exclamation-triangle" style="color: var(--danger);"></i>
                         <p>Error al cargar los datos de la tabla</p>
                     </td>
@@ -604,7 +618,7 @@ class Dashboard {
         if (tableBody) {
             tableBody.innerHTML = `
                 <tr>
-                    <td colspan="6" class="empty-state">
+                    <td colspan="7" class="empty-state">
                         <i class="fas fa-exclamation-triangle" style="color: var(--danger);"></i>
                         <p>Error al cargar los datos: ${this.state.error?.message || 'Error desconocido'}</p>
                         <p style="font-size: 0.8rem; margin-top: 0.5rem;">


### PR DESCRIPTION
## Summary
- add pastel purple color variable and button styles
- include 'Dashboard' column in indicators table
- show a 'Ver' button for dashboard link when available
- update JS table logic to generate dashboard link and adjust column span

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_68410f39a2b4833081622ef111f001ec