### PR TITLE
Ajustes de estilo para búsqueda en tabla

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -324,9 +324,17 @@ body {
 }
 
 .table-search-section {
-    background: var(--light-gray);
+    background: var(--medium-gray);
     padding: 1rem 2rem;
     border-bottom: 2px solid var(--medium-gray);
+}
+
+.results-counter {
+    text-align: right;
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--dark-blue);
+    margin-top: 0.5rem;
 }
 
 .table-container {

--- a/css/variables.css
+++ b/css/variables.css
@@ -6,6 +6,7 @@
     --secondary-blue: #00bfff;
     --light-blue: #89cfeb;
     --accent-blue: #add8e6;
+    --dark-blue: #003366;
     
     /* Status Colors */
     --success: #28a745;

--- a/js/filterManager.js
+++ b/js/filterManager.js
@@ -368,15 +368,6 @@ class FilterManager {
         if (counter) {
             const total = this.originalData.length;
             counter.textContent = `Mostrando ${FormatUtils.formatNumber(count)} de ${FormatUtils.formatNumber(total)} indicadores`;
-            
-            // Estilo dinámico basado en cantidad de resultados
-            if (count === 0) {
-                counter.style.color = 'var(--danger)';
-            } else if (count < total * 0.1) {
-                counter.style.color = 'var(--warning)';
-            } else {
-                counter.style.color = 'var(--dark-gray)';
-            }
         }
     }
 
@@ -389,13 +380,6 @@ class FilterManager {
 
         const counter = document.createElement('div');
         counter.className = 'results-counter';
-        counter.style.cssText = `
-            text-align: right;
-            font-size: 0.9rem;
-            color: var(--dark-gray);
-            opacity: 0.8;
-            margin-top: 0.5rem;
-        `;
 
         searchSection.appendChild(counter);
         return counter;


### PR DESCRIPTION
## Summary
- agregar nuevo color `--dark-blue`
- cambiar fondo de la sección de búsqueda de la tabla y definir estilo de `.results-counter`
- simplificar creación y actualización del contador de resultados

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_68430569912083308087bd57208c0fab