### PR TITLE
Visual improvements and dark mode

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -60,6 +60,19 @@ body {
     box-shadow: var(--shadow-light);
 }
 
+.theme-toggle {
+    background: none;
+    border: none;
+    color: var(--light-gray);
+    font-size: 1.4rem;
+    cursor: pointer;
+    transition: var(--transition);
+}
+
+.theme-toggle:hover {
+    color: var(--white);
+}
+
 .logo {
     width: 50px;
     height: 50px;
@@ -74,6 +87,7 @@ body {
 }
 
 .header h1 {
+    font-family: var(--font-family-display);
     font-size: 2.2rem;
     font-weight: 600;
     margin: 0;
@@ -110,6 +124,13 @@ body {
     color: var(--primary-blue);
     font-weight: 600;
     font-size: 1.1rem;
+}
+
+.filters-count {
+    text-align: right;
+    font-size: 0.85rem;
+    color: var(--dark-gray);
+    margin-bottom: 1rem;
 }
 
 .filters-grid {
@@ -181,8 +202,8 @@ body {
 
 .stat-card {
     background: var(--white);
-    border-radius: var(--border-radius);
-    padding: 2rem;
+    border-radius: var(--border-radius-large);
+    padding: 2.5rem 2rem;
     box-shadow: var(--shadow);
     transition: var(--transition);
     position: relative;
@@ -363,14 +384,15 @@ body {
     z-index: 10;
 }
 
+
 .indicators-table td {
     padding: 1rem;
     border-bottom: 1px solid var(--medium-gray);
-    font-size: 0.95rem;
+    font-size: 1rem;
 }
 
 .indicators-table tr:hover {
-    background: var(--light-gray);
+    background: var(--beach-beige);
 }
 
 /* Button for dashboard links */
@@ -402,6 +424,7 @@ body {
     }
 
     .header h1 {
+        font-family: var(--font-family-display);
         font-size: 1.8rem;
     }
 

--- a/css/silbi.css
+++ b/css/silbi.css
@@ -8,6 +8,8 @@
   font-family:Arial, sans-serif;
 }
 #silbi-inner{position:relative;width:100%;}
+.silbi-settings{position:absolute;top:-10px;left:-10px;background:#fff;border:none;border-radius:50%;width:28px;height:28px;box-shadow:0 2px 6px rgba(0,0,0,0.2);cursor:pointer;}
+.silbi-settings i{color:#333;}
 #silbi-character{width:100%;animation:bounce 3s infinite ease-in-out;cursor:pointer;display:block;}
 @keyframes bounce{
   0%,100%{transform:translate(0,0);}

--- a/css/variables.css
+++ b/css/variables.css
@@ -7,6 +7,9 @@
     --light-blue: #89cfeb;
     --accent-blue: #add8e6;
     --dark-blue: #003366;
+    /* New natural palette */
+    --manabi-green: #4caf50;
+    --beach-beige: #f5deb3;
     
     /* Status Colors */
     --success: #28a745;
@@ -46,6 +49,7 @@
     
     /* Typography */
     --font-family-primary: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    --font-family-display: 'Poppins', Arial, sans-serif;
     --font-family-mono: 'Courier New', monospace;
     
     --font-size-xs: 0.75rem;
@@ -90,19 +94,19 @@
     --input-border-error: 2px solid var(--danger);
     
     /* Charts */
-    --chart-color-1: #1f8fff;
-    --chart-color-2: #00bfff;
-    --chart-color-3: #89cfeb;
-    --chart-color-4: #add8e6;
-    --chart-color-5: #b1e0e7;
-    --chart-color-6: #b1e0e7;
+    --chart-color-1: #04724D;
+    --chart-color-2: #8DB600;
+    --chart-color-3: #FFBC42;
+    --chart-color-4: #E9967A;
+    --chart-color-5: #114B5F;
+    --chart-color-6: #8DB600;
 
     /* Component Color Palette */
-    --color-1: #1f8fff;
-    --color-2: #00bfff;
-    --color-3: #89cfeb;
-    --color-4: #add8e6;
-    --color-5: #b1e0e7;
+    --color-1: var(--chart-color-1);
+    --color-2: var(--chart-color-2);
+    --color-3: var(--chart-color-3);
+    --color-4: var(--chart-color-4);
+    --color-5: var(--chart-color-5);
 
     /* Highlight */
     --highlight-orange: #ffe5b4;
@@ -141,6 +145,19 @@
         --shadow-hover: 0 4px 20px rgba(0, 0, 0, 0.4);
         --shadow-light: 0 1px 5px rgba(0, 0, 0, 0.2);
     }
+}
+
+/* Manual dark mode toggle */
+body.dark-mode {
+    --white: #1a1a1a;
+    --light-gray: #2d2d2d;
+    --medium-gray: #404040;
+    --dark-gray: #e0e0e0;
+    --black: #ffffff;
+
+    --shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+    --shadow-hover: 0 4px 20px rgba(0, 0, 0, 0.4);
+    --shadow-light: 0 1px 5px rgba(0, 0, 0, 0.2);
 }
 
 /* High contrast mode support */

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <!-- External Dependencies -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap">
     
     <!-- CSS Modules -->
     <link rel="stylesheet" href="css/variables.css">
@@ -38,6 +39,9 @@
                 </div>
             </div>
             <img class="header-emblem" src="img/manabi.png" alt="Escudo de Manabí">
+            <button id="themeToggle" class="theme-toggle" aria-label="Alternar modo oscuro">
+                <i class="fas fa-moon"></i>
+            </button>
         </div>
     </header>
 
@@ -49,6 +53,7 @@
                 <i class="fas fa-search"></i>
                 <span id="filters-title">Filtros de Búsqueda</span>
             </div>
+            <div id="activeFiltersCount" class="filters-count"></div>
             
             <div class="filters-grid">
                 <div class="filter-group">
@@ -205,7 +210,7 @@
                             <th scope="col">Sector Estadístico</th>
                             <th scope="col">ID RA</th>
                             <th scope="col">Periodicidad</th>
-                            <th scope="col">Dashboard</th>
+                            <th scope="col">Dashboard <i class="fas fa-question-circle" title="Panel de visualización resumido"></i></th>
                         </tr>
                     </thead>
                     <tbody id="indicatorsTableBody">
@@ -225,6 +230,9 @@
 
     <div id="silbi-container">
         <div id="silbi-inner">
+            <button id="silbi-settings" class="silbi-settings" aria-label="Configurar asistente" title="Configurar">
+                <i class="fas fa-volume-mute"></i>
+            </button>
             <div id="silbi-emote">😊</div>
             <img id="silbi-character" src="img/silbi.png" alt="SILBí personaje" />
         </div>
@@ -242,6 +250,7 @@
     <script src="js/chartManager.js"></script>
     <script src="js/filterManager.js"></script>
     <script src="js/dashboard.js"></script>
+    <script src="js/themeToggle.js"></script>
     <script src="js/silbi.js"></script>
 </body>
 </html>

--- a/js/config.js
+++ b/js/config.js
@@ -5,19 +5,19 @@ const CONFIG = {
     
     // Chart Configuration - Paleta de colores para componentes
     CHART_COLORS: [
-        '#1f8fff',
-        '#00bfff',
-        '#89cfeb',
-        '#add8e6',
-        '#b1e0e7'
+        '#04724D',
+        '#8DB600',
+        '#FFBC42',
+        '#E9967A',
+        '#114B5F'
     ],
     
     // Colores específicos para periodicidad
     PERIODICITY_COLORS: [
-        '#1f8fff', // Mensual - Azul primario
-        '#00bfff', // Trimestral - Azul claro
-        '#89cfeb', // Semestral - Celeste
-        '#add8e6'  // Anual - Azul pastel
+        '#04724D', // Mensual
+        '#8DB600', // Trimestral
+        '#FFBC42', // Semestral
+        '#E9967A'  // Anual
     ],
     
     // Data Configuration

--- a/js/filterManager.js
+++ b/js/filterManager.js
@@ -121,9 +121,9 @@ class FilterManager {
         // Placeholder dinámico para búsqueda
         if (this.elements.search) {
             const placeholders = [
-                'Escribe el nombre del indicador...',
-                'Buscar por descripción...',
-                'Ejemplo: población, educación, salud...'
+                'Ejemplo: Mortalidad infantil',
+                'Busca por tema o palabra clave',
+                'Filtra indicadores aquí...'
             ];
             
             let currentIndex = 0;
@@ -209,8 +209,9 @@ class FilterManager {
                 console.warn('⚠️ No hay callback configurado para onFilterChange');
             }
 
-            // Actualizar contador de resultados
+            // Actualizar contador de resultados y filtros activos
             this.updateResultsCounter(filteredData.length);
+            this.updateActiveFilterCount();
 
             // Anunciar cambios para accesibilidad
             AccessibilityUtils.announceToScreenReader(
@@ -372,6 +373,17 @@ class FilterManager {
     }
 
     /**
+     * Actualiza el número de filtros activos
+     */
+    updateActiveFilterCount() {
+        const countElem = DOMUtils.safeQuerySelector('#activeFiltersCount');
+        if (!countElem) return;
+
+        const active = this.getFilterStats().activeFilters;
+        countElem.textContent = active > 0 ? `${active} filtro(s) activo(s)` : 'Sin filtros activos';
+    }
+
+    /**
      * Crea el elemento contador de resultados
      */
     createResultsCounter() {
@@ -420,6 +432,7 @@ class FilterManager {
 
             // Aplicar filtros (que ahora están vacíos)
             this.applyFilters();
+            this.updateActiveFilterCount();
 
             // Limpiar UI de búsqueda
             this.updateSearchUI('');

--- a/js/silbi.js
+++ b/js/silbi.js
@@ -20,8 +20,11 @@ const closeButton = document.getElementById("silbi-close");
 const silbi = document.getElementById("silbi-character");
 const emote = document.getElementById("silbi-emote");
 const sound = document.getElementById("emote-sound");
+const settingsBtn = document.getElementById("silbi-settings");
+let silbiEnabled = true;
 let index = 0;
 let hideTimeout;
+let messageInterval;
 
 function showMessage() {
   messageSpan.textContent = messages[index];
@@ -34,7 +37,7 @@ function showMessage() {
 }
 function cycleMessages() {
   showMessage();
-  setInterval(showMessage, 8000);
+  messageInterval = setInterval(showMessage, 8000);
 }
 function showRandomEmote() {
   const random = emoticons[Math.floor(Math.random() * emoticons.length)];
@@ -51,3 +54,17 @@ closeButton.addEventListener("click", () => {
 });
 silbi.addEventListener("click", showRandomEmote);
 window.addEventListener("load", cycleMessages);
+
+if (settingsBtn) {
+  settingsBtn.addEventListener("click", () => {
+    silbiEnabled = !silbiEnabled;
+    if (!silbiEnabled) {
+      clearInterval(messageInterval);
+      bubble.classList.remove("show");
+      settingsBtn.querySelector("i").className = "fas fa-volume-off";
+    } else {
+      cycleMessages();
+      settingsBtn.querySelector("i").className = "fas fa-volume-mute";
+    }
+  });
+}

--- a/js/themeToggle.js
+++ b/js/themeToggle.js
@@ -1,0 +1,19 @@
+// js/themeToggle.js
+// Simple theme toggle for dark mode
+
+document.addEventListener('DOMContentLoaded', () => {
+  const button = document.getElementById('themeToggle');
+  if (!button) return;
+
+  button.addEventListener('click', () => {
+    document.body.classList.toggle('dark-mode');
+    const icon = button.querySelector('i');
+    if (document.body.classList.contains('dark-mode')) {
+      icon.classList.remove('fa-moon');
+      icon.classList.add('fa-sun');
+    } else {
+      icon.classList.remove('fa-sun');
+      icon.classList.add('fa-moon');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- refresh color palette and typography variables
- redesign statistic cards and table hover color
- display number of active filters
- allow toggling dark mode
- add assistant mute option

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_6843542d4c9c833090655edb9363cf86