### PR TITLE
Implement Horizon-style dashboard layout

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -14,10 +14,59 @@ body {
 }
 
 /* Header */
+/* Layout */
+.layout {
+    display: flex;
+}
+
+.sidebar {
+    width: 220px;
+    background: var(--white);
+    border-right: 1px solid var(--medium-gray);
+    min-height: 100vh;
+    padding: 1rem;
+    position: fixed;
+    top: 0;
+    left: 0;
+}
+
+.nav-links {
+    list-style: none;
+    margin-top: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.nav-links a {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    color: var(--primary-blue);
+    padding: 0.6rem 0.8rem;
+    border-radius: var(--border-radius-large);
+    text-decoration: none;
+    font-weight: 600;
+    transition: var(--transition-fast);
+}
+
+.nav-links a:hover {
+    background: var(--light-gray);
+}
+
+.sidebar i {
+    font-size: 1.2rem;
+}
+
+.main-content {
+    margin-left: 220px;
+    flex: 1;
+}
+
 .header {
-    background: linear-gradient(90deg, var(--primary-blue) 0%, var(--color-5-70) 100%);
-    color: var(--light-gray);
-    padding: 1.5rem 0;
+    background: var(--white);
+    color: var(--dark-gray);
+    padding: 1rem 2rem;
     box-shadow: var(--shadow);
     position: sticky;
     top: 0;
@@ -43,6 +92,51 @@ body {
     position: relative; /* permite posicionar elementos absolutamente */
 }
 
+.header-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.search-bar {
+    position: relative;
+}
+
+.search-bar input {
+    padding: 0.5rem 2.2rem 0.5rem 0.75rem;
+    border-radius: var(--border-radius-large);
+    border: 1px solid var(--medium-gray);
+    background: var(--white);
+}
+
+.search-bar i {
+    position: absolute;
+    right: 0.75rem;
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--dark-gray);
+}
+
+.icon-btn {
+    background: none;
+    border: none;
+    font-size: 1.2rem;
+    color: var(--dark-gray);
+    cursor: pointer;
+    transition: var(--transition-fast);
+}
+
+.icon-btn:hover {
+    color: var(--primary-blue);
+}
+
+.avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
 .logo-section {
     display: flex;
     align-items: center;
@@ -63,14 +157,14 @@ body {
 .theme-toggle {
     background: none;
     border: none;
-    color: var(--light-gray);
+    color: var(--dark-gray);
     font-size: 1.4rem;
     cursor: pointer;
     transition: var(--transition);
 }
 
 .theme-toggle:hover {
-    color: var(--white);
+    color: var(--primary-blue);
 }
 
 .logo {
@@ -195,7 +289,7 @@ body {
 /* Statistics Cards */
 .stats-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
     gap: 1.5rem;
     margin-bottom: 2rem;
 }
@@ -411,8 +505,62 @@ body {
     opacity: 0.85;
 }
 
+/* Tasks and Calendar */
+.tasks-calendar {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2rem;
+    margin-bottom: 2rem;
+}
+
+.task-list {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.task-item {
+    background: var(--white);
+    border-radius: var(--border-radius-large);
+    padding: 1rem;
+    box-shadow: var(--shadow);
+}
+
+.calendar {
+    background: var(--white);
+    border-radius: var(--border-radius-large);
+    padding: 1rem;
+    box-shadow: var(--shadow);
+}
+
+.calendar-table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: center;
+}
+
+.calendar-table th,
+.calendar-table td {
+    padding: 0.25rem;
+}
+
+.calendar-table caption {
+    text-align: left;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
+    .sidebar {
+        display: none;
+    }
+
+    .main-content {
+        margin-left: 0;
+    }
     .container {
         padding: 1rem;
     }
@@ -437,6 +585,10 @@ body {
     }
 
     .charts-section {
+        grid-template-columns: 1fr;
+    }
+
+    .tasks-calendar {
         grid-template-columns: 1fr;
     }
 

--- a/css/variables.css
+++ b/css/variables.css
@@ -2,11 +2,11 @@
 :root {
     /* Primary Colors */
     /* Updated palette */
-    --primary-blue: #1f8fff;
-    --secondary-blue: #00bfff;
-    --light-blue: #89cfeb;
-    --accent-blue: #add8e6;
-    --dark-blue: #003366;
+    --primary-blue: #7159ff;
+    --secondary-blue: #8e7bff;
+    --light-blue: #c9c2ff;
+    --accent-blue: #e6e2ff;
+    --dark-blue: #463099;
     /* New natural palette */
     --manabi-green: #4caf50;
     --beach-beige: #f5deb3;

--- a/index.html
+++ b/index.html
@@ -27,23 +27,43 @@
     <!-- Notification Container -->
     <div id="notificationContainer" class="notification-container"></div>
 
-    <!-- Header -->
-    <header class="header">
-        <div class="header-content">
-            <div class="logo-section">
-                <!-- <div class="logo">SIL</div> -->
-                <div>
-                    <h1 class="color-1">Sistema de Información Local [SIL]</h1>
-                    <div class="header-subtitle color-2">Dashboard de Indicadores</div>
-                    <div class="header-subtitle color-2">Gobierno Autónomo Descentralizado Provincial de Manabí</div>
+    <div class="layout">
+        <nav class="sidebar">
+            <div class="logo">SIL</div>
+            <ul class="nav-links">
+                <li><a href="#stats-title"><i class="fas fa-th-large"></i><span>Resumen</span></a></li>
+                <li><a href="#charts-title"><i class="fas fa-chart-pie"></i><span>Gráficas</span></a></li>
+                <li><a href="#table-title"><i class="fas fa-table"></i><span>Tabla</span></a></li>
+                <li><a href="#tasks-section"><i class="fas fa-check-square"></i><span>Tareas</span></a></li>
+                <li><a href="#calendar-section"><i class="fas fa-calendar"></i><span>Calendario</span></a></li>
+            </ul>
+        </nav>
+        <div class="main-content">
+        <!-- Header -->
+        <header class="header">
+            <div class="header-content">
+                <div class="logo-section">
+                    <!-- <div class="logo">SIL</div> -->
+                    <div>
+                        <h1 class="color-1">Sistema de Información Local [SIL]</h1>
+                        <div class="header-subtitle color-2">Dashboard de Indicadores</div>
+                        <div class="header-subtitle color-2">Gobierno Autónomo Descentralizado Provincial de Manabí</div>
+                    </div>
+                </div>
+                <div class="header-actions">
+                    <div class="search-bar">
+                        <input type="search" placeholder="Buscar...">
+                        <i class="fas fa-search"></i>
+                    </div>
+                    <button class="icon-btn" aria-label="Notificaciones"><i class="fas fa-bell"></i></button>
+                    <button class="icon-btn" aria-label="Configuración"><i class="fas fa-cog"></i></button>
+                    <img src="img/silbico.png" alt="Usuario" class="avatar">
+                    <button id="themeToggle" class="theme-toggle" aria-label="Alternar modo oscuro">
+                        <i class="fas fa-moon"></i>
+                    </button>
                 </div>
             </div>
-            <img class="header-emblem" src="img/manabi.png" alt="Escudo de Manabí">
-            <button id="themeToggle" class="theme-toggle" aria-label="Alternar modo oscuro">
-                <i class="fas fa-moon"></i>
-            </button>
-        </div>
-    </header>
+        </header>
 
     <!-- Main Container -->
     <main class="container">
@@ -200,8 +220,8 @@
                 </div>
             </div>
 
-            <div class="table-container">
-                <table class="indicators-table" role="table" aria-labelledby="table-title">
+        <div class="table-container">
+            <table class="indicators-table" role="table" aria-labelledby="table-title">
                     <thead>
                         <tr>
                             <th scope="col">Nombre del Indicador</th>
@@ -222,9 +242,22 @@
                         </tr>
                     </tbody>
                 </table>
-            </div>
+        </div>
+    </section>
+
+    <section class="tasks-calendar">
+        <div class="tasks-section" id="tasks-section">
+            <h2><i class="fas fa-check-circle"></i> Tareas</h2>
+            <ul id="taskList" class="task-list"></ul>
+        </div>
+        <div class="calendar-section" id="calendar-section">
+            <h2><i class="fas fa-calendar"></i> Calendario</h2>
+            <div id="calendarContainer" class="calendar"></div>
+        </div>
     </section>
     </main>
+        </div> <!-- end main-content -->
+    </div> <!-- end layout -->
 
     <audio id="emote-sound" src="audio/pop.mp3" preload="auto"></audio>
 
@@ -251,6 +284,7 @@
     <script src="js/filterManager.js"></script>
     <script src="js/dashboard.js"></script>
     <script src="js/themeToggle.js"></script>
+    <script src="js/tasksCalendar.js"></script>
     <script src="js/silbi.js"></script>
 </body>
 </html>

--- a/js/tasksCalendar.js
+++ b/js/tasksCalendar.js
@@ -1,0 +1,69 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const tasks = [
+    { text: 'Actualizar indicadores', done: false },
+    { text: 'Revisar fuentes de datos', done: true },
+    { text: 'Preparar informe mensual', done: false }
+  ];
+
+  const list = document.getElementById('taskList');
+  if (list) {
+    tasks.forEach(t => {
+      const li = document.createElement('li');
+      li.className = 'task-item';
+      li.innerHTML = `<label><input type="checkbox" ${t.done ? 'checked' : ''}> ${t.text}</label>`;
+      list.appendChild(li);
+    });
+  }
+
+  renderCalendar();
+});
+
+function renderCalendar() {
+  const container = document.getElementById('calendarContainer');
+  if (!container) return;
+
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth();
+
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const table = document.createElement('table');
+  table.className = 'calendar-table';
+
+  const caption = document.createElement('caption');
+  const monthNames = ['Enero','Febrero','Marzo','Abril','Mayo','Junio','Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'];
+  caption.textContent = `${monthNames[month]} ${year}`;
+  table.appendChild(caption);
+
+  const headerRow = document.createElement('tr');
+  ['Dom','Lun','Mar','Mié','Jue','Vie','Sáb'].forEach(d => {
+    const th = document.createElement('th');
+    th.textContent = d;
+    headerRow.appendChild(th);
+  });
+  table.appendChild(headerRow);
+
+  let row = document.createElement('tr');
+  for (let i=0; i<firstDay; i++) {
+    row.appendChild(document.createElement('td'));
+  }
+
+  for (let day=1; day<=daysInMonth; day++) {
+    if (row.children.length === 7) {
+      table.appendChild(row);
+      row = document.createElement('tr');
+    }
+    const td = document.createElement('td');
+    td.textContent = day;
+    row.appendChild(td);
+  }
+
+  while (row.children.length < 7) {
+    row.appendChild(document.createElement('td'));
+  }
+  table.appendChild(row);
+
+  container.appendChild(table);
+}


### PR DESCRIPTION
## Summary
- update color palette with violet tones
- add sidebar navigation and responsive main layout
- redesign header with search and control icons
- include tasks list and calendar sections
- style new elements and create script to render tasks and calendar

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_684394c55f5483309c9d82c12a5a330c