### PR TITLE
Add info overlay for components

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -468,3 +468,57 @@ body {
     outline: 3px solid var(--light-blue);
     outline-offset: 2px;
 }
+
+/* Info icon next to filter labels */
+.info-btn {
+    background: none;
+    border: none;
+    color: var(--primary-blue);
+    cursor: pointer;
+    margin-left: 0.25rem;
+    font-size: 0.9rem;
+}
+
+.info-btn i {
+    pointer-events: none;
+}
+
+/* Glass morphism overlay for extra info */
+.info-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(255, 255, 255, 0.2);
+    backdrop-filter: blur(8px);
+    -webkit-backdrop-filter: blur(8px);
+    z-index: var(--z-overlay);
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+}
+
+.info-content {
+    background: rgba(255, 255, 255, 0.4);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border-radius: var(--border-radius-large);
+    box-shadow: var(--shadow-hover);
+    max-width: 600px;
+    color: var(--dark-gray);
+    padding: 2rem;
+    position: relative;
+}
+
+.info-close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    color: var(--dark-gray);
+    cursor: pointer;
+}

--- a/index.html
+++ b/index.html
@@ -56,7 +56,11 @@
             
             <div class="filters-grid">
                 <div class="filter-group">
-                    <label class="filter-label" for="component-filter">Componente</label>
+                    <label class="filter-label" for="component-filter">Componente
+                        <button id="componentInfoBtn" class="info-btn" type="button" aria-label="Más información">
+                            <i class="fas fa-info-circle"></i>
+                        </button>
+                    </label>
                     <select class="filter-select" id="component-filter" aria-describedby="component-help">
                         <option value="">Todos los componentes</option>
                     </select>
@@ -227,6 +231,17 @@
 
     <audio id="emote-sound" src="audio/pop.mp3" preload="auto"></audio>
 
+    <div id="componentInfoOverlay" class="info-overlay" aria-modal="true" role="dialog" aria-labelledby="componentInfoTitle">
+        <div class="info-content">
+            <button id="componentInfoClose" class="info-close" aria-label="Cerrar">×</button>
+            <h2 id="componentInfoTitle" class="sr-only">Más información</h2>
+            <p><strong>Territorial:</strong> Nodo que concentrará toda la información estadística y geográfica del ámbito territorial que se derive de la producción de información generada en las direcciones que aportan con datos al componente Territorial.</p>
+            <p><strong>Atención Ciudadana:</strong> Nodo que concentrará toda la información relacionada con las actividades y medios para facilitar el ejercicio de derechos ciudadanos: protección de grupos de atención prioritaria, seguridad y temas de cooperación internacional.</p>
+            <p><strong>Administrativo Financiero:</strong> Nodo que concentrará toda la información Administrativa Financiera institucional.</p>
+            <p><strong>Institucional:</strong> Nodo que concentrará toda la información derivada de la Gestión Interna y Externa de la Institución y que incluye el Marco Regulatorio Institucional.</p>
+        </div>
+    </div>
+
     <div id="silbi-container">
         <div id="silbi-inner">
             <div id="silbi-emote">😊</div>
@@ -248,6 +263,7 @@
     <script src="js/filterManager.js"></script>
     <script src="js/dashboard.js"></script>
     <script src="js/themeToggle.js"></script>
+    <script src="js/componentInfo.js"></script>
     <script src="js/silbi.js"></script>
 </body>
 </html>

--- a/js/componentInfo.js
+++ b/js/componentInfo.js
@@ -1,0 +1,19 @@
+// js/componentInfo.js
+
+// Muestra información adicional sobre los componentes
+
+document.addEventListener('DOMContentLoaded', () => {
+  const infoBtn = document.getElementById('componentInfoBtn');
+  const overlay = document.getElementById('componentInfoOverlay');
+  const closeBtn = document.getElementById('componentInfoClose');
+
+  if (!infoBtn || !overlay || !closeBtn) return;
+
+  infoBtn.addEventListener('click', () => {
+    overlay.style.display = 'flex';
+  });
+
+  closeBtn.addEventListener('click', () => {
+    overlay.style.display = 'none';
+  });
+});


### PR DESCRIPTION
## Summary
- add info icon next to *Componente* filter
- display information overlay describing the component nodes
- style overlay with glass morphism effect
- add JS to handle opening and closing the info dialog

## Testing
- `node tests/test-csv-parser.js`


------
https://chatgpt.com/codex/tasks/task_e_6843a72ef1bc833094f9d0a314abc794