### PR TITLE
Update dark mode toggle placement and style

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -49,36 +49,55 @@ body {
     gap: 1rem;
 }
 
+.header-right {
+    position: absolute;
+    top: 50%;
+    right: 2rem;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
 .header-emblem {
     height: 70px;
     object-fit: contain;
-    position: absolute; /* colocar sobre el listón */
-    top: 50%;
-    transform: translateY(-50%);
-    right: 2rem;
-    z-index: 101;
     transition: var(--transition);
 }
 
 .header-emblem:hover {
-    transform: translateY(-50%) scale(1.05);
+    transform: scale(1.05);
 }
 
 .theme-toggle {
-    background: none;
+    width: 50px;
+    height: 24px;
+    background: var(--dark-blue);
     border: none;
-    color: var(--light-gray);
-    font-size: 1.4rem;
+    border-radius: 12px;
+    position: relative;
     cursor: pointer;
     transition: var(--transition);
+}
+
+.theme-toggle::after {
+    content: '';
     position: absolute;
-    top: 50%;
-    right: 6rem;
-    transform: translateY(-50%);
+    width: 20px;
+    height: 20px;
+    background: var(--white);
+    border-radius: 50%;
+    top: 2px;
+    left: 2px;
+    transition: var(--transition);
+}
+
+body.dark-mode .theme-toggle::after {
+    transform: translateX(26px);
 }
 
 .theme-toggle:hover {
-    color: var(--white);
+    box-shadow: var(--shadow-hover);
 }
 
 .logo {

--- a/index.html
+++ b/index.html
@@ -37,10 +37,10 @@
                     <div class="header-subtitle color-2">Dashboard de Indicadores</div>
                 </div>
             </div>
-            <img class="header-emblem" src="img/manabi.png" alt="Escudo de Manabí">
-            <button id="themeToggle" class="theme-toggle" aria-label="Alternar modo oscuro">
-                <i class="fas fa-moon"></i>
-            </button>
+            <div class="header-right">
+                <button id="themeToggle" class="theme-toggle" aria-label="Alternar modo oscuro"></button>
+                <img class="header-emblem" src="img/manabi.png" alt="Escudo de Manabí">
+            </div>
         </div>
     </header>
 

--- a/js/themeToggle.js
+++ b/js/themeToggle.js
@@ -7,13 +7,5 @@ document.addEventListener('DOMContentLoaded', () => {
 
   button.addEventListener('click', () => {
     document.body.classList.toggle('dark-mode');
-    const icon = button.querySelector('i');
-    if (document.body.classList.contains('dark-mode')) {
-      icon.classList.remove('fa-moon');
-      icon.classList.add('fa-sun');
-    } else {
-      icon.classList.remove('fa-sun');
-      icon.classList.add('fa-moon');
-    }
   });
 });


### PR DESCRIPTION
## Summary
- position toggle beside manabi emblem
- restyle toggle as dark-blue switch
- simplify theme toggle script

## Testing
- `node tests/test-csv-parser.js`


------
https://chatgpt.com/codex/tasks/task_e_6843a93105e48330adf4cede893a72a4