### PR TITLE
Improve Componentes popup UI

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -499,15 +499,63 @@ body {
     color: var(--dark-gray);
     padding: 2rem;
     position: relative;
+    font-size: var(--font-size-lg);
+}
+
+.info-content::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, var(--primary-blue), var(--light-blue));
+    border-top-left-radius: var(--border-radius-large);
+    border-top-right-radius: var(--border-radius-large);
 }
 
 .info-close {
     position: absolute;
     top: 0.5rem;
     right: 0.5rem;
-    background: none;
+    width: 32px;
+    height: 32px;
+    background: linear-gradient(135deg, var(--primary-blue), var(--light-blue));
     border: none;
-    font-size: 1.5rem;
-    color: var(--dark-gray);
+    border-radius: 50%;
+    color: var(--white);
+    font-size: 1.2rem;
     cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.info-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+}
+
+.info-header h2 {
+    margin: 0;
+    font-size: var(--font-size-xl);
+}
+
+.info-logo {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    overflow: hidden;
+    background: linear-gradient(135deg, var(--primary-blue), var(--light-blue));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.info-logo img {
+    width: 70%;
+    height: 70%;
 }

--- a/index.html
+++ b/index.html
@@ -233,7 +233,12 @@
     <div id="componentInfoOverlay" class="info-overlay" aria-modal="true" role="dialog" aria-labelledby="componentInfoTitle">
         <div class="info-content">
             <button id="componentInfoClose" class="info-close" aria-label="Cerrar">×</button>
-            <h2 id="componentInfoTitle" class="sr-only">Más información</h2>
+            <div class="info-header">
+                <h2 id="componentInfoTitle">Componentes</h2>
+                <div class="info-logo">
+                    <img src="img/silbico.png" alt="SILBico">
+                </div>
+            </div>
             <p><strong>Territorial:</strong> Nodo que concentrará toda la información estadística y geográfica del ámbito territorial que se derive de la producción de información generada en las direcciones que aportan con datos al componente Territorial.</p>
             <p><strong>Atención Ciudadana:</strong> Nodo que concentrará toda la información relacionada con las actividades y medios para facilitar el ejercicio de derechos ciudadanos: protección de grupos de atención prioritaria, seguridad y temas de cooperación internacional.</p>
             <p><strong>Administrativo Financiero:</strong> Nodo que concentrará toda la información Administrativa Financiera institucional.</p>


### PR DESCRIPTION
## Summary
- redesign the info popup for Componentes
- show a visible heading
- add logo and circular close button
- match dashboard border styling and increase text size

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_6843aca6966883309564570e9ae43e16