### PR TITLE
Align silbico logo to left in info popup

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -534,7 +534,8 @@ body {
 .info-header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-start;
+    gap: 1rem;
     margin-bottom: 1rem;
 }
 
@@ -548,12 +549,13 @@ body {
     height: 100px;
     border-radius: 50%;
     overflow: hidden;
-    background: linear-gradient(135deg, var(--primary-blue), var(--light-blue));
+    border: 4px solid transparent;
+    border-image: linear-gradient(90deg, var(--primary-blue), var(--light-blue)) 1;
+    background: none;
     display: flex;
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
-    margin-left: auto;
 }
 
 .info-logo img {

--- a/index.html
+++ b/index.html
@@ -234,10 +234,10 @@
         <div class="info-content">
             <button id="componentInfoClose" class="info-close" aria-label="Cerrar">×</button>
             <div class="info-header">
-                <h2 id="componentInfoTitle">Componentes</h2>
                 <div class="info-logo">
                     <img src="img/silbico.png" alt="SILBico">
                 </div>
+                <h2 id="componentInfoTitle">Componentes</h2>
             </div>
             <p><strong>Territorial:</strong> Nodo que concentrará toda la información estadística y geográfica del ámbito territorial que se derive de la producción de información generada en las direcciones que aportan con datos al componente Territorial.</p>
             <p><strong>Atención Ciudadana:</strong> Nodo que concentrará toda la información relacionada con las actividades y medios para facilitar el ejercicio de derechos ciudadanos: protección de grupos de atención prioritaria, seguridad y temas de cooperación internacional.</p>


### PR DESCRIPTION
## Summary
- reposition info popup logo so silbico circle appears before the title
- use same gradient border as popup header and remove background on the logo

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_6843af5b2ea88330b0294f867c58cbeb