### PR TITLE
Improve README data documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,32 @@ Run the CSV parser test with:
 
 ```bash
 node tests/test-csv-parser.js
+```
+
+## CSV column reference
+
+The dataset used by the dashboard (`data/indicators.csv`) provides multiple
+attributes for each indicator. The following table summarizes the meaning of
+each column:
+
+| Column             | Description                                                                 |
+|--------------------|-----------------------------------------------------------------------------|
+| `N`                | Sequential number for the record.                                           |
+| `Componente`       | Component or domain the indicator belongs to.                               |
+| `Direccion`        | Direction/department responsible for the indicator.                         |
+| `Id_RA`            | Identifier of the administrative record.                                    |
+| `Registro_Administrativo` | Name of the administrative record.                             |
+| `Indicador`        | Short indicator code.                                                       |
+| `Nombre_Indicador` | Full name of the indicator.                                                 |
+| `SectorE`          | Sector classification used for grouping.                                    |
+| `Dashboard`        | Dashboard or view where the indicator is displayed.                         |
+| `Tematica`         | Thematic area of the indicator.                                             |
+| `Eje_PDOT`         | Axis in the PDOT development plan.                                          |
+| `5P1`              | Primary classification within the "5P" framework (People, Planet, etc.).    |
+| `5P2`              | Secondary "5P" classification (often empty).                                |
+| `ODS1`‑`ODS6`      | Up to six Sustainable Development Goals linked to the indicator.            |
+
+The CSV parser defined in `js/csvParser.js` validates that the columns
+`Componente`, `Direccion` and `SectorE` are present. Fields such as
+`Nombre_Indicador`, `N`, `Id_RA`, `Registro_Administrativo` and `Indicador` are
+optional but supported when available.


### PR DESCRIPTION
## Summary
- document columns found in `data/indicators.csv`
- mention required and optional fields for the CSV parser
- fix incomplete code block in README

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_68472338fd4083308aff78989621a810