### PR TITLE
Add FilterManager and chart empty-data tests

### DIFF
--- a/tests/test-chart-manager.js
+++ b/tests/test-chart-manager.js
@@ -1,0 +1,64 @@
+const assert = require('assert');
+
+// Minimal DOM stubs
+global.window = { addEventListener() {} };
+
+global.document = {
+    querySelector(selector) {
+        if (selector === '#componentChart' || selector === '#periodicityChart') {
+            return { getContext: () => ({}) };
+        }
+        if (selector.endsWith('Loading') || selector.endsWith('Error')) {
+            return { style: {}, innerHTML: '', querySelector: () => ({ textContent: '' }) };
+        }
+        return null;
+    },
+    querySelectorAll: () => [],
+    addEventListener: () => {},
+    body: { appendChild() {}, removeChild() {} }
+};
+
+global.CONFIG = {
+    CHART_COLORS: ['#1','#2','#3','#4'],
+    PERIODICITY_COLORS: ['#1','#2','#3','#4'],
+    PERIODICITIES: ['Mensual','Trimestral','Semestral','Anual'],
+    CHART_ANIMATION_DURATION: 0,
+    MAX_CHART_ITEMS: 10
+};
+
+global.NotificationManager = { show: () => {} };
+
+class FakeChart {
+    constructor(ctx, cfg) {
+        this.data = JSON.parse(JSON.stringify(cfg.data));
+        this.options = cfg.options || {};
+    }
+    update() {}
+    destroy() {}
+    resize() {}
+    toBase64Image() { return ''; }
+    getDatasetMeta() { return { data: [{x:0,y:0},{x:0,y:0},{x:0,y:0},{x:0,y:0}] }; }
+}
+
+global.Chart = FakeChart;
+
+require('../js/utils.js');
+global.DOMUtils = global.window.DOMUtils;
+global.PerformanceUtils = global.window.PerformanceUtils;
+global.ErrorUtils = global.window.ErrorUtils;
+require('../js/chartManager.js');
+
+const ChartManager = global.window.ChartManager;
+
+const cm = new ChartManager();
+cm.initialize();
+
+let emptyCalled = false;
+cm.showEmptyChart = function(id) { if (id === 'componentChart') emptyCalled = true; };
+
+cm.updateCharts([]);
+
+assert.strictEqual(emptyCalled, true, 'showEmptyChart should be called for empty component data');
+assert.deepStrictEqual(cm.charts.periodicity.data.datasets[0].data, [0,0,0,0], 'Periodicity chart uses zeroes for empty dataset');
+
+console.log('ChartManager tests passed.');

--- a/tests/test-filter-manager.js
+++ b/tests/test-filter-manager.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const assert = require('assert');
+
+// Minimal DOM stubs
+global.window = {};
+global.document = {
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    addEventListener: () => {},
+    body: { appendChild() {}, removeChild() {} }
+};
+
+global.CONFIG = {
+    FIELD_MAPPING: {
+        component: ['Componente'],
+        direction: ['Direccion'],
+        sector: ['SectorE'],
+        registroAdmin: ['Registro_Administrativo'],
+        idRA: ['Id_RA'],
+        indicatorName: ['Nombre_Indicador']
+    },
+    FALLBACK_VALUES: { indicatorName: '' },
+    REQUIRED_COLUMNS: ['Componente', 'Direccion', 'SectorE']
+};
+
+global.NotificationManager = { show: () => {} };
+
+require('../js/utils.js');
+// Expose utils assigned to window as globals for convenience
+global.DataUtils = global.window.DataUtils;
+global.PerformanceUtils = global.window.PerformanceUtils;
+global.ErrorUtils = global.window.ErrorUtils;
+require('../js/csvParser.js');
+require('../js/filterManager.js');
+
+const CSVParser = global.window.CSVParser;
+const FilterManager = global.window.FilterManager;
+
+const csv = fs.readFileSync(__dirname + '/fixtures/sample.csv', 'utf8');
+const records = CSVParser.parse(csv);
+
+const fm = new FilterManager();
+fm.originalData = records;
+
+// No filters
+let result = fm.filterData(records, { component: '', direction: '', sector: '', search: '' });
+assert.strictEqual(result.length, 2, 'No filters should return all records');
+
+// Component filter
+result = fm.filterData(records, { component: 'Comp1', direction: '', sector: '', search: '' });
+assert.strictEqual(result.length, 1, 'Component filter should match one record');
+assert.strictEqual(result[0].Componente, 'Comp1');
+
+// Direction filter
+result = fm.filterData(records, { component: '', direction: 'Dir2', sector: '', search: '' });
+assert.strictEqual(result.length, 1, 'Direction filter should match one record');
+assert.strictEqual(result[0].Direccion, 'Dir2');
+
+// Search filter
+result = fm.filterData(records, { component: '', direction: '', sector: '', search: 'eñe' });
+assert.strictEqual(result.length, 1, 'Search filter should match by indicator name');
+assert.strictEqual(result[0].Nombre_Indicador, 'Indicador con eñe ñ');
+
+// hasActiveFilters
+assert.strictEqual(fm.hasActiveFilters(), false, 'Initially no active filters');
+fm.filters.component = 'Comp1';
+assert.strictEqual(fm.hasActiveFilters(), true, 'Detect active filters');
+fm.filters.component = '';
+assert.strictEqual(fm.hasActiveFilters(), false, 'Detect clearing of filters');
+
+// getFilterStats
+fm.filters.direction = 'Dir1';
+const stats = fm.getFilterStats();
+assert.strictEqual(stats.activeFilters, 1, 'getFilterStats counts active filters');
+assert.strictEqual(stats.originalDataCount, 2, 'getFilterStats reports original data count');
+
+console.log('FilterManager tests passed.');


### PR DESCRIPTION
## Summary
- add tests covering filter behaviour in `FilterManager`
- add tests verifying `ChartManager` handles empty datasets

## Testing
- `node tests/test-csv-parser.js`
- `node tests/test-filter-manager.js`
- `node tests/test-chart-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_6847233d66948330a11e9181c0735ac7