### PR TITLE
Move active filter count

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -124,10 +124,10 @@ body {
 }
 
 .filters-count {
-    text-align: right;
+    text-align: left;
     font-size: 0.85rem;
     color: var(--dark-gray);
-    margin-bottom: 1rem;
+    margin-top: 1rem;
 }
 
 .filters-grid {

--- a/index.html
+++ b/index.html
@@ -79,8 +79,6 @@
                 <i class="fas fa-search"></i>
                 <span id="filters-title">Filtros de Búsqueda</span>
             </div>
-            <div id="activeFiltersCount" class="filters-count"></div>
-            
             <div class="filters-grid">
                 <div class="filter-group">
                     <label class="filter-label" for="component-filter"><i class="fas fa-layer-group"></i> Componente
@@ -106,8 +104,9 @@
                     <datalist id="theme-options"></datalist>
                     <div id="theme-help" class="sr-only">Selecciona un registro administrativo para filtrar los indicadores</div>
                 </div>
-
             </div>
+
+            <div id="activeFiltersCount" class="filters-count"></div>
         </section>
 
         <!-- Statistics Cards -->


### PR DESCRIPTION
## Summary
- reposition `activeFiltersCount` to the bottom of the filters section
- align the counter text to the left

## Testing
- `node tests/test-csv-parser.js`
- `node tests/test-filter-manager.js`
- `node tests/test-chart-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_68474fdfd11c83309133c0ab0977f9bd