### PR TITLE
Remove update card and adjust Silbi size

### DIFF
--- a/css/silbi.css
+++ b/css/silbi.css
@@ -8,19 +8,19 @@
   font-family:Arial, sans-serif;
 }
 #silbi-inner{position:relative;width:100%;}
-#silbi-character{width:100%;animation:bounce 3s infinite ease-in-out;cursor:pointer;display:block;}
+#silbi-character{width:80%;animation:bounce 3s infinite ease-in-out;cursor:pointer;display:block;}
 @keyframes bounce{
   0%,100%{transform:translate(0,0);}
-  25%{transform:translate(-5px,-5px);}
-  50%{transform:translate(5px,-10px);}
-  75%{transform:translate(-5px,-5px);}
+  25%{transform:translate(-3px,-3px);}
+  50%{transform:translate(3px,-6px);}
+  75%{transform:translate(-3px,-3px);}
 }
-#silbi-bubble{position:absolute;bottom:240px;right:0;background-color:#fff;color:#333;padding:12px 16px;border-radius:15px;box-shadow:0 4px 12px rgba(0,0,0,0.15);font-size:14px;max-width:230px;opacity:0;transform:translateY(10px);transition:all 0.5s ease;pointer-events:none;}
-#silbi-bubble::after{content:'';position:absolute;bottom:-10px;right:30px;border-width:10px 10px 0 10px;border-style:solid;border-color:#ffffff transparent transparent transparent;}
+#silbi-bubble{position:absolute;bottom:200px;right:0;background-color:#fff;color:#333;padding:8px 12px;border-radius:15px;box-shadow:0 4px 12px rgba(0,0,0,0.15);font-size:12px;max-width:150px;opacity:0;transform:translateY(10px);transition:all 0.5s ease;pointer-events:none;}
+#silbi-bubble::after{content:'';position:absolute;bottom:-8px;right:20px;border-width:10px 10px 0 10px;border-style:solid;border-color:#ffffff transparent transparent transparent;}
 #silbi-bubble.show{opacity:1;transform:translateY(0);pointer-events:auto;}
-#silbi-close{position:absolute;top:-10px;right:-10px;background:#f00;color:#fff;border:none;border-radius:50%;width:22px;height:22px;font-size:14px;cursor:pointer;z-index:10;}
+#silbi-close{position:absolute;top:-10px;right:-10px;background:#f00;color:#fff;border:none;border-radius:50%;width:22px;height:22px;font-size:12px;cursor:pointer;z-index:10;}
 #silbi-emote{position:absolute;top:72%;left:43%;transform:translate(-50%, -50%) scale(0);font-size:40px;opacity:0;animation:zoomEffect 2s ease-in-out forwards;pointer-events:none;z-index:10;}
 @keyframes zoomEffect{0%{transform:translate(-50%, -50%) scale(0.2);opacity:0;}60%{transform:translate(-50%, -50%) scale(1.2);opacity:1;}100%{transform:translate(-50%, -50%) scale(0);opacity:0;}}
-@media(max-width:600px){#silbi-container{width:140px;bottom:10px;right:10px;}#silbi-bubble{bottom:190px;font-size:12px;max-width:180px;}#silbi-bubble::after{right:20px;}#silbi-emote{font-size:30px;top:75%;left:41%;}}
+@media(max-width:600px){#silbi-container{width:140px;bottom:10px;right:10px;}#silbi-bubble{bottom:160px;font-size:10px;max-width:150px;}#silbi-bubble::after{right:16px;}#silbi-emote{font-size:30px;top:75%;left:41%;}}
 
 #gadpm-phrase{margin-top:4px;text-align:center;font-weight:bold;font-size:1rem;color:var(--dark-gray);}

--- a/index.html
+++ b/index.html
@@ -139,16 +139,8 @@
                 <div class="stat-value">0</div>
                 <div class="stat-description">Áreas de desarrollo territorial</div>
             </div>
-
-            <div class="stat-card" id="updateCard">
-                <div class="stat-header">
-                    <div class="stat-title">Última Actualización</div>
-                    <div class="stat-icon"><i class="fas fa-sync-alt"></i></div>
-                </div>
-                <div class="stat-value">Junio</div>
-                <div class="stat-description">2025 - Datos actualizados mensualmente</div>
-            </div>
         </section>
+
 
         <!-- Charts Section -->
         <section class="charts-section" role="region" aria-labelledby="charts-title">

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -395,13 +395,8 @@ class Dashboard {
             DOMUtils.safeSetContent('#totalIndicatorsCard .stat-value', FormatUtils.formatNumber(stats.total));
             DOMUtils.safeSetContent('#registrosCard .stat-value', FormatUtils.formatNumber(stats.uniqueRAs));
             DOMUtils.safeSetContent('#componentsCard .stat-value', FormatUtils.formatNumber(stats.uniqueComponents));
+            console.log("✅ Tarjetas de estadísticas actualizadas");
             
-            // Actualizar fecha de actualización
-            const currentDate = new Date();
-            const monthName = FormatUtils.formatDate(currentDate, { month: 'long' });
-            DOMUtils.safeSetContent('#updateCard .stat-value', FormatUtils.capitalizeWords(monthName));
-            
-            console.log('✅ Tarjetas de estadísticas actualizadas');
             
         } catch (error) {
             ErrorUtils.handleError(error, 'Actualización de Estadísticas');


### PR DESCRIPTION
## Summary
- drop obsolete updateCard section from dashboard
- shrink the Silbi assistant character and speech bubble
- update stats card logic accordingly

## Testing
- `node tests/test-chart-manager.js`
- `node tests/test-csv-parser.js`
- `node tests/test-filter-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_6847742929e88330b680e3c6a3d033c4