### PR TITLE
Remove duplicate notifications and slow loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,6 +286,7 @@
     <!-- JavaScript Modules -->
     <script src="js/config.js"></script>
     <script src="js/utils.js"></script>
+    <script src="js/initCleanup.js"></script>
     <script src="js/notificationManager.js"></script>
     <script src="js/csvParser.js"></script>
     <script src="js/progressLoader.js"></script>

--- a/js/initCleanup.js
+++ b/js/initCleanup.js
@@ -1,0 +1,12 @@
+// js/initCleanup.js
+// Remove duplicate notification containers on page load
+// Some pages accidentally render multiple #notificationContainer elements.
+// We keep the first one and remove the rest to avoid duplicated notifications.
+document.addEventListener('DOMContentLoaded', () => {
+    const containers = document.querySelectorAll('#notificationContainer');
+    if (containers.length > 1) {
+        containers.forEach((el, idx) => {
+            if (idx > 0) el.remove();
+        });
+    }
+});

--- a/js/progressLoader.js
+++ b/js/progressLoader.js
@@ -63,10 +63,13 @@ class ProgressLoader {
     finish() {
         this.setProgress(this.totalItems);
         if (this.overlay) {
-            this.overlay.classList.add('fade-out');
+            // Add delay so the loading card remains visible a bit longer
             setTimeout(() => {
-                this.overlay.style.display = 'none';
-            }, 500);
+                this.overlay.classList.add('fade-out');
+                setTimeout(() => {
+                    this.overlay.style.display = 'none';
+                }, 500);
+            }, 3000); // extra 3 seconds to appreciate progress bar
         }
     }
 }


### PR DESCRIPTION
## Summary
- clean up extra `notificationContainer` elements on page load
- extend progress loader duration so the loading card stays visible 3 seconds more
- include new cleanup script in `index.html`

## Testing
- `node tests/test-csv-parser.js`
- `node tests/test-filter-manager.js`
- `node tests/test-chart-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_68477a28d25883308b501c40ba0fb631