### PR TITLE
Remove startup notification

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -99,11 +99,6 @@ class Dashboard {
             }
 
             this.state.filteredData = [...this.state.data];
-            
-            NotificationManager.show(
-                `${CONFIG.SUCCESS_MESSAGES.dataLoaded}: ${this.state.data.length} indicadores`,
-                'success'
-            );
 
             timer.end();
 

--- a/js/notificationManager.js
+++ b/js/notificationManager.js
@@ -4,6 +4,10 @@ class NotificationManager {
         const container = document.getElementById('notificationContainer');
         if (!container) return;
 
+        if (container.style.display === 'none') {
+            container.style.display = 'block';
+        }
+
         const notification = document.createElement('div');
         notification.className = `notification ${type}`;
         
@@ -47,7 +51,11 @@ class NotificationManager {
         if (notification && notification.parentNode) {
             notification.style.animation = 'slideOut 0.3s ease-out forwards';
             setTimeout(() => {
+                const container = notification.parentNode;
                 notification.remove();
+                if (container.children.length === 0) {
+                    container.style.display = 'none';
+                }
             }, 300);
         }
     }

--- a/js/progressLoader.js
+++ b/js/progressLoader.js
@@ -89,8 +89,6 @@ class ProgressLoader {
                 this.overlay.classList.add('fade-out');
                 setTimeout(() => {
                     this.overlay.style.display = 'none';
-                    const container = document.getElementById('notificationContainer');
-                    if (container) container.style.display = 'block';
                 }, 500);
             }, 3000); // extra time to read messages
         }


### PR DESCRIPTION
## Summary
- remove initial 'data loaded' notification from dashboard loadData
- show/hide notification container only when notifications exist
- stop progress loader from forcing notification container display

## Testing
- `node tests/test-filter-manager.js`
- `node tests/test-chart-manager.js`
- `node tests/test-csv-parser.js`


------
https://chatgpt.com/codex/tasks/task_e_6847826e42fc833084253c716f710ab4