### PR TITLE
Adjust UI for SILBI and ODS panel

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -593,6 +593,8 @@ body {
     font-size: var(--font-size-lg);
     margin-bottom: var(--spacing-md);
     color: var(--primary-blue);
+    border-bottom: 1px solid var(--medium-gray);
+    padding-bottom: var(--spacing-xs);
 }
 
 .ods-grid {

--- a/css/silbi.css
+++ b/css/silbi.css
@@ -8,7 +8,7 @@
   font-family:Arial, sans-serif;
 }
 #silbi-inner{position:relative;width:100%;}
-#silbi-character{width:80%;animation:bounce 3s infinite ease-in-out;cursor:pointer;display:block;margin-left:auto;}
+#silbi-character{width:80%;animation:bounce 3s infinite ease-in-out;cursor:pointer;display:block;margin-left:auto;margin-right:-8px;}
 @keyframes bounce{
   0%,100%{transform:translate(0,0);}
   25%{transform:translate(-3px,-3px);}
@@ -19,7 +19,7 @@
 #silbi-bubble::after{content:'';position:absolute;bottom:-8px;right:20px;border-width:10px 10px 0 10px;border-style:solid;border-color:#ffffff transparent transparent transparent;}
 #silbi-bubble.show{opacity:1;transform:translateY(0);pointer-events:auto;}
 #silbi-close{position:absolute;top:-10px;right:-10px;background:#f00;color:#fff;border:none;border-radius:50%;width:22px;height:22px;font-size:12px;cursor:pointer;z-index:10;}
-#silbi-emote{position:absolute;top:72%;left:43%;transform:translate(-50%, -50%) scale(0);font-size:40px;opacity:0;animation:zoomEffect 2s ease-in-out forwards;pointer-events:none;z-index:10;}
+#silbi-emote{position:absolute;top:72%;left:48%;transform:translate(-50%, -50%) scale(0);font-size:40px;opacity:0;animation:zoomEffect 2s ease-in-out forwards;pointer-events:none;z-index:10;}
 @keyframes zoomEffect{0%{transform:translate(-50%, -50%) scale(0.2);opacity:0;}60%{transform:translate(-50%, -50%) scale(1.2);opacity:1;}100%{transform:translate(-50%, -50%) scale(0);opacity:0;}}
 @media(max-width:600px){#silbi-container{width:140px;bottom:10px;right:10px;}#silbi-bubble{bottom:160px;font-size:10px;max-width:150px;}#silbi-bubble::after{right:16px;}#silbi-emote{font-size:30px;top:75%;left:41%;}}
 


### PR DESCRIPTION
## Summary
- tweak bottom border for ODS sidebar heading
- nudge SILBÍ character image to the right
- adjust emoticon popup position

## Testing
- `node tests/test-chart-manager.js && node tests/test-csv-parser.js && node tests/test-filter-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_6847842d476c8330922eb498444fabb7