### PR TITLE
Dim non-selected ODS icons

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -622,6 +622,10 @@ body {
     filter: grayscale(100%) brightness(70%);
 }
 
+.ods-item.dimmed {
+    filter: grayscale(60%) brightness(80%);
+}
+
 .ods-item.highlight {
     outline: 3px solid var(--primary-blue);
 }

--- a/js/odsPanel.js
+++ b/js/odsPanel.js
@@ -86,6 +86,8 @@ const ODSPanel = {
         this.showInfo(odsToClear);
       }, 0);
     }
+
+    this.updateSelectedStyles();
   },
 
   toggleODS(num) {
@@ -108,8 +110,14 @@ const ODSPanel = {
       const num = parseInt(el.dataset.num, 10);
       if (this.activeODS === num) {
         el.classList.add('highlight');
+        el.classList.remove('dimmed');
       } else {
         el.classList.remove('highlight');
+        if (this.activeODS !== null) {
+          el.classList.add('dimmed');
+        } else {
+          el.classList.remove('dimmed');
+        }
       }
     });
   },


### PR DESCRIPTION
## Summary
- add dimmed style for ODS icons
- apply `dimmed` class to unselected ODS icons in panel

## Testing
- `node tests/test-chart-manager.js`
- `node tests/test-csv-parser.js`
- `node tests/test-filter-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_68478a2063908330ae2a2a22e6966e04