### PR TITLE
Show bubble and reset filters on ODS7 click

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -666,3 +666,37 @@ body {
     font-size: var(--font-size-xs);
     line-height: var(--line-height-tight);
 }
+
+.ods-bubble {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%) translateY(-10px);
+    background: var(--white);
+    color: var(--dark-gray);
+    padding: 6px 10px;
+    border-radius: 15px;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+    font-size: var(--font-size-xs);
+    max-width: 160px;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s, transform 0.3s;
+    z-index: var(--z-notification);
+}
+
+.ods-bubble.show {
+    opacity: 1;
+    transform: translateX(-50%) translateY(-20px);
+}
+
+.ods-bubble::after {
+    content: '';
+    position: absolute;
+    bottom: -8px;
+    left: 50%;
+    transform: translateX(-50%);
+    border-width: 10px 10px 0 10px;
+    border-style: solid;
+    border-color: var(--white) transparent transparent transparent;
+}

--- a/index.html
+++ b/index.html
@@ -86,6 +86,7 @@
                     <h3 id="ods-title"></h3>
                     <p id="ods-description"></p>
                 </div>
+                <div id="ods-bubble" class="ods-bubble" aria-live="polite"></div>
             </aside>
             <div class="dashboard-main">
         <!-- Filters Section -->

--- a/js/odsPanel.js
+++ b/js/odsPanel.js
@@ -5,6 +5,7 @@ const ODSPanel = {
     this.items = Array.from(document.querySelectorAll('.ods-item'));
     this.titleEl = document.getElementById('ods-title');
     this.descEl = document.getElementById('ods-description');
+    this.bubbleEl = document.getElementById('ods-bubble');
     this.activeODS = null;
     this.odsInfo = [
       { num:1, title:'Fin de la Pobreza', desc:'Fin de la pobreza en todas sus formas en todo el mundo.' },
@@ -28,12 +29,31 @@ const ODSPanel = {
     this.items.forEach(item => {
       item.addEventListener('click', () => {
         const num = parseInt(item.dataset.num, 10);
+        if (num === 7 && !this.extractODSSet(this.data).has(7)) {
+          this.showBubble('ODS sin indicador relacionado');
+          if (this.filterManager) {
+            this.filterManager.clearAllFilters();
+          }
+          this.activeODS = null;
+          this.highlightForData(this.data);
+          this.showInfo(num);
+          return;
+        }
         this.toggleODS(num);
         this.showInfo(num);
       });
     });
     this.markInactive();
     this.highlightForData(this.data);
+  },
+  showBubble(message) {
+    if (!this.bubbleEl) return;
+    this.bubbleEl.textContent = message;
+    this.bubbleEl.classList.add('show');
+    clearTimeout(this.bubbleTimeout);
+    this.bubbleTimeout = setTimeout(() => {
+      this.bubbleEl.classList.remove('show');
+    }, 3000);
   },
   extractODSSet(dataset) {
     const set = new Set();


### PR DESCRIPTION
## Summary
- add bubble element in ODS panel
- style bubble in dashboard.css
- show warning bubble when clicking ODS7 if it has no indicators
- clear filters and reload panel after showing the bubble

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_68478dd4e9dc83309d75519562468f5c