### PR TITLE
Update ODS panel border style

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -611,7 +611,7 @@ body {
     overflow: hidden;
     cursor: pointer;
     transition: var(--transition);
-    border: 3px solid var(--ods-color, transparent);
+    border: 3px solid transparent;
 }
 
 .ods-item:hover {
@@ -628,7 +628,8 @@ body {
 }
 
 .ods-item.highlight {
-    outline: 3px solid var(--ods-color, var(--primary-blue));
+    outline: none;
+    border-color: var(--ods-color, var(--primary-blue));
 }
 
 /* Official ODS colors */


### PR DESCRIPTION
## Summary
- keep ODS item border hidden by default
- show ODS item border when the item is highlighted

## Testing
- `node tests/test-csv-parser.js`
- `node tests/test-chart-manager.js`
- `node tests/test-filter-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_68478e8e1fec8330bc3e90d0fd77fcbb