### PR TITLE
Improve ODS panel tooltip positioning

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -670,9 +670,9 @@ body {
 
 .ods-bubble {
     position: absolute;
-    bottom: 100%;
+    top: 0;
     left: 50%;
-    transform: translateX(-50%) translateY(-10px);
+    transform: translate(-50%, -10px);
     background: var(--white);
     color: var(--dark-gray);
     padding: 6px 10px;
@@ -688,7 +688,7 @@ body {
 
 .ods-bubble.show {
     opacity: 1;
-    transform: translateX(-50%) translateY(-20px);
+    transform: translate(-50%, -20px);
 }
 
 .ods-bubble::after {

--- a/js/odsPanel.js
+++ b/js/odsPanel.js
@@ -30,7 +30,7 @@ const ODSPanel = {
       item.addEventListener('click', () => {
         const num = parseInt(item.dataset.num, 10);
         if (num === 7 && !this.extractODSSet(this.data).has(7)) {
-          this.showBubble('ODS sin indicador relacionado');
+          this.showBubble('ODS sin indicador relacionado', item);
           if (this.filterManager) {
             this.filterManager.clearAllFilters();
           }
@@ -46,9 +46,22 @@ const ODSPanel = {
     this.markInactive();
     this.highlightForData(this.data);
   },
-  showBubble(message) {
+  showBubble(message, targetEl) {
     if (!this.bubbleEl) return;
     this.bubbleEl.textContent = message;
+
+    if (targetEl) {
+      const panelRect = this.bubbleEl.parentElement.getBoundingClientRect();
+      const targetRect = targetEl.getBoundingClientRect();
+      const left = targetRect.left - panelRect.left + targetRect.width / 2;
+      const top = targetRect.top - panelRect.top;
+      this.bubbleEl.style.left = `${left}px`;
+      this.bubbleEl.style.top = `${top}px`;
+    } else {
+      this.bubbleEl.style.left = '50%';
+      this.bubbleEl.style.top = '';
+    }
+
     this.bubbleEl.classList.add('show');
     clearTimeout(this.bubbleTimeout);
     this.bubbleTimeout = setTimeout(() => {


### PR DESCRIPTION
## Summary
- position the ODS info bubble next to the clicked icon
- update click handler to pass target element

## Testing
- `node tests/test-csv-parser.js`
- `node tests/test-chart-manager.js`
- `node tests/test-filter-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_6847900129308330a68a5c4668d97c5b