### PR TITLE
Integrate circular loading ring

### DIFF
--- a/css/loader.css
+++ b/css/loader.css
@@ -99,6 +99,46 @@ body.loading-screen {
     animation: slide 2s ease-in-out infinite;
 }
 
+/* Circular progress ring styles */
+.ring-container {
+    position: relative;
+    width: 150px;
+    height: 150px;
+    margin: 0 auto 2rem;
+}
+
+.ring {
+    width: 100%;
+    height: 100%;
+}
+
+.ring circle {
+    fill: none;
+    stroke-width: 12;
+    transform: rotate(-90deg);
+    transform-origin: 50% 50%;
+    stroke-linecap: round;
+}
+
+.ring-bg {
+    stroke: rgba(255, 255, 255, 0.2);
+}
+
+.ring-bar {
+    stroke: url(#loader-grad);
+    stroke-dasharray: 472;
+    stroke-dashoffset: 472;
+    transition: stroke-dashoffset var(--transition);
+}
+
+.ring-container .percentage {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    margin: 0;
+}
+
 @keyframes shimmer {
     0% { background-position: -200% 0; }
     100% { background-position: 200% 0; }

--- a/index.html
+++ b/index.html
@@ -24,11 +24,20 @@
     <div id="progressOverlay" class="progress-overlay">
         <div class="particles" id="particles"></div>
         <div class="loading-container glass-morphism" id="loadingContainer">
-            <div class="logo">Cargando dashboard SIL</div>
-            <div class="progress-container">
-                <div class="progress-bar" id="progressBar"></div>
+            <div class="logo">Dashboard SIL</div>
+            <div class="ring-container">
+                <svg class="ring" viewBox="0 0 150 150">
+                    <defs>
+                        <linearGradient id="loader-grad" x1="0%" y1="0%" x2="100%" y2="0%">
+                            <stop offset="0%" stop-color="var(--primary-blue)" />
+                            <stop offset="100%" stop-color="var(--light-blue)" />
+                        </linearGradient>
+                    </defs>
+                    <circle class="ring-bg" cx="75" cy="75" r="70" />
+                    <circle class="ring-bar" cx="75" cy="75" r="70" />
+                </svg>
+                <div class="percentage" id="percentage">0%</div>
             </div>
-            <div class="percentage" id="percentage">0%</div>
             <div class="loading-text" id="loadingText">Iniciando sistema<span class="dots"></span></div>
         </div>
     </div>

--- a/js/progressLoader.js
+++ b/js/progressLoader.js
@@ -4,6 +4,7 @@ class ProgressLoader {
         this.progress = 0;
         this.animationFrame = null;
         this.progressBar = DOMUtils.safeQuerySelector('#progressBar');
+        this.ringBar = DOMUtils.safeQuerySelector('.ring-bar');
         this.percentage = DOMUtils.safeQuerySelector('#percentage');
         this.loadingText = DOMUtils.safeQuerySelector('#loadingText');
         this.overlay = DOMUtils.safeQuerySelector('#progressOverlay');
@@ -17,6 +18,11 @@ class ProgressLoader {
             'Preparando dashboard',
             'Finalizando carga'
         ];
+        if (this.ringBar) {
+            this.ringTotal = this.ringBar.getTotalLength();
+            this.ringBar.style.strokeDasharray = this.ringTotal;
+            this.ringBar.style.strokeDashoffset = this.ringTotal;
+        }
         this.setProgress(0);
         this.createParticles();
     }
@@ -44,6 +50,10 @@ class ProgressLoader {
     setProgress(value) {
         const percent = Math.min(Math.floor(value), 100);
         if (this.progressBar) this.progressBar.style.width = `${percent}%`;
+        if (this.ringBar) {
+            const offset = this.ringTotal * (1 - percent / 100);
+            this.ringBar.style.strokeDashoffset = offset;
+        }
         if (this.percentage) this.percentage.textContent = `${percent}%`;
         const index = Math.floor((percent / 100) * (this.messages.length - 1));
         const msg = this.messages[index] || this.messages[0];


### PR DESCRIPTION
## Summary
- update loader overlay to use circular progress indicator
- add ring styles to loader.css
- update ProgressLoader to animate ring dash offset

## Testing
- `node tests/test-csv-parser.js && node tests/test-filter-manager.js && node tests/test-chart-manager.js`

------
https://chatgpt.com/codex/tasks/task_e_68479750c69c8330ae6ae53f7635ca45