### PR TITLE
Improve loading screen layout and speed

### DIFF
--- a/css/loader.css
+++ b/css/loader.css
@@ -50,11 +50,12 @@ body.loading-screen {
     display: block;
 }
 
-.loading-container .logo {
-    font-size: 2.5rem;
+.loading-title {
+    font-size: 3rem;
     font-weight: var(--font-weight-semibold);
     margin-bottom: 2rem;
-    color: var(--white);
+    color: var(--color-1);
+    text-align: center;
     text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
     animation: glow 2s ease-in-out infinite alternate;
 }
@@ -212,7 +213,7 @@ body.loading-screen {
     .progress-container {
         width: 300px;
     }
-    .loading-container .logo {
+    .loading-title {
         font-size: 2rem;
     }
     .percentage {

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
     <div id="progressOverlay" class="progress-overlay">
         <div class="particles" id="particles"></div>
         <div class="loading-container glass-morphism" id="loadingContainer">
-            <div class="logo">Dashboard SIL</div>
+            <h1 class="loading-title color-1">Dashboard SIL</h1>
             <div class="ring-container">
                 <svg class="ring" viewBox="0 0 150 150">
                     <defs>

--- a/js/progressLoader.js
+++ b/js/progressLoader.js
@@ -1,5 +1,5 @@
 class ProgressLoader {
-    constructor(duration = 8000) {
+    constructor(duration = 12000) {
         this.duration = duration;
         this.progress = 0;
         this.animationFrame = null;


### PR DESCRIPTION
## Summary
- tweak loading overlay html to remove `.logo` and use `.loading-title` class
- use larger font size and palette color for the dashboard title
- slow down the progress bar duration

## Testing
- `node tests/test-csv-parser.js`
- `node tests/test-filter-manager.js`
- `node tests/test-chart-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_684799530f5c8330bfff1c6fc7df4610