### PR TITLE
Fix loader text color

### DIFF
--- a/css/loader.css
+++ b/css/loader.css
@@ -54,7 +54,7 @@ body.loading-screen {
     font-size: 3rem;
     font-weight: var(--font-weight-semibold);
     margin-bottom: 2rem;
-    color: var(--color-1);
+    color: var(--color-5);
     text-align: center;
     text-shadow: 0 2px 4px rgba(0, 0, 0, 0.6);
     animation: glow 2s ease-in-out infinite alternate;
@@ -162,6 +162,7 @@ body.loading-screen {
     opacity: 0.9;
     margin: 1rem 0;
     min-height: 1.5rem;
+    color: var(--color-5);
 }
 
 .dots {


### PR DESCRIPTION
## Summary
- use dark palette color on loading-title
- update loading-text to share the same dark color

## Testing
- `node tests/test-csv-parser.js`
- `node tests/test-filter-manager.js`
- `node tests/test-chart-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_68479b61d4988330b667b44e3d2f5a2f