### PR TITLE
Add 5P and 5EPDOT sections

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -265,6 +265,40 @@ body {
     opacity: 0.8;
 }
 
+/* Five P container */
+.fivep-images {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.fivep-images img {
+    width: 48px;
+    height: 48px;
+    cursor: pointer;
+}
+
+.stat-footer {
+    text-align: center;
+    font-size: 0.9rem;
+    color: var(--dark-gray);
+    opacity: 0.8;
+}
+
+.epdot-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--dark-gray);
+}
+
+.epdot-list li {
+    margin: 0.2rem 0;
+}
+
 /* Charts Section */
 .charts-section {
     display: grid;

--- a/index.html
+++ b/index.html
@@ -131,7 +131,32 @@
         <!-- Statistics Cards -->
         <section class="stats-grid" role="region" aria-labelledby="stats-title">
             <h2 id="stats-title" class="sr-only">Estadísticas Generales</h2>
-            
+
+            <div class="stat-card" id="fivepCard">
+                <div class="fivep-images">
+                    <img src="img/p1.png" alt="Personas" data-label="Personas">
+                    <img src="img/p2.png" alt="Paz" data-label="Paz">
+                    <img src="img/p3.png" alt="Pactos/Alianzas" data-label="Pactos/Alianzas">
+                    <img src="img/p4.png" alt="Planeta" data-label="Planeta">
+                    <img src="img/p5.png" alt="Prosperidad" data-label="Prosperidad">
+                </div>
+                <div class="stat-footer" id="fivepFooter"></div>
+            </div>
+
+            <div class="stat-card" id="fiveepdotCard">
+                <div class="stat-header">
+                    <div class="stat-title">5E PDOT</div>
+                    <div class="stat-icon"><i class="fas fa-map"></i></div>
+                </div>
+                <ul class="epdot-list">
+                    <li>Manabí Integrado</li>
+                    <li>Manabí Vivo y Sostenible</li>
+                    <li>Manabí Humano</li>
+                    <li>Manabí Próspero</li>
+                    <li>Manabí Estratégico</li>
+                </ul>
+            </div>
+
             <div class="stat-card" id="totalIndicatorsCard">
                 <div class="stat-header">
                     <div class="stat-title">Total de Indicadores</div>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -719,14 +719,25 @@ document.addEventListener('DOMContentLoaded', async () => {
     
     try {
         dashboardInstance = new Dashboard();
-        
+
         // Hacer la instancia disponible globalmente para debugging
         window.dashboard = dashboardInstance;
-        
+
+        const footer = DOMUtils.safeQuerySelector('#fivepFooter');
+        const imgs = DOMUtils.safeQuerySelectorAll('#fivepCard img');
+        imgs.forEach(img => {
+            img.addEventListener('click', () => {
+                const label = img.getAttribute('data-label') || img.alt || '';
+                if (footer) {
+                    footer.textContent = label;
+                }
+            });
+        });
+
     } catch (error) {
         ErrorUtils.handleError(error, 'Inicialización del Sistema');
     }
 });
 
 // Exportar para uso en otros módulos
-window.Dashboard = Dashboard;
+window.Dashboard = Dashboard


### PR DESCRIPTION
## Summary
- include new 5P and 5EPDOT stat cards with the same style
- show PDOT axes in the 5EPDOT card
- add CSS rules for cards and images
- update JS to show the name of clicked 5P image

## Testing
- `node tests/test-csv-parser.js`
- `node tests/test-chart-manager.js`
- `node tests/test-filter-manager.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68479e18a94c833088c120a682281b2e