### PR TITLE
Implement tooltips and styled footers

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -300,7 +300,7 @@ body {
 }
 
 .fivep-images img {
-    width: 48px;
+    width: 64px;
     height: 48px;
     cursor: pointer;
 }
@@ -325,6 +325,12 @@ body {
     font-size: 0.9rem;
     color: var(--dark-gray);
     opacity: 0.8;
+}
+
+#fivepFooter,
+#fiveepdotFooter {
+    font-weight: bold;
+    animation: glow 2s ease-in-out infinite alternate;
 }
 
 .epdot-list {

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
         <section class="stats-grid" role="region" aria-labelledby="stats-title">
             <h2 id="stats-title" class="sr-only">Estadísticas Generales</h2>
 
-            <div class="stat-card" id="fivepCard">
+            <div class="stat-card" id="fivepCard" title="Espacio destinado a las 5P">
                 <div class="fivep-images">
                     <img src="img/p1.png" alt="Personas" data-label="Personas">
                     <img src="img/p2.png" alt="Paz" data-label="Paz">
@@ -146,7 +146,7 @@
                 <div class="stat-footer" id="fivepFooter"></div>
             </div>
 
-            <div class="stat-card" id="fiveepdotCard">
+            <div class="stat-card" id="fiveepdotCard" title="Cinco Ejes del PDOT">
                 <div class="epdot-images">
                     <img src="img/5e1.png" alt="Manabí Vivo-Sostenible" data-label="Manabí Vivo-Sostenible">
                     <img src="img/5e2.png" alt="Manabí Integrado" data-label="Manabí Integrado">


### PR DESCRIPTION
## Summary
- show tooltip text for 5P and PDOT cards
- adjust 5P images so they're wider than tall
- add glowing bold style for `fivepFooter` and `fiveepdotFooter`

## Testing
- `node tests/test-csv-parser.js`

------
https://chatgpt.com/codex/tasks/task_e_684848eed72c8330abebf7bbeb93226f