### PR TITLE
Add tooltip bubble for dashboard cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,6 +156,7 @@
                 </div>
                 <div class="stat-footer" id="fiveepdotFooter"></div>
             </div>
+            <div id="card-bubble" class="ods-bubble" aria-live="polite"></div>
         </section>
 
         <section class="stats-grid" role="region" aria-labelledby="stats-extra-title">

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -734,6 +734,30 @@ document.addEventListener('DOMContentLoaded', async () => {
             });
         });
 
+        const cardBubble = DOMUtils.safeQuerySelector('#card-bubble');
+
+        function showCardBubble(message, targetEl) {
+            if (!cardBubble || !targetEl) return;
+            cardBubble.textContent = message;
+            const containerRect = cardBubble.parentElement.getBoundingClientRect();
+            const targetRect = targetEl.getBoundingClientRect();
+            const left = targetRect.left - containerRect.left + targetRect.width / 2;
+            const top = targetRect.top - containerRect.top;
+            cardBubble.style.left = `${left}px`;
+            cardBubble.style.top = `${top}px`;
+            cardBubble.classList.add('show');
+        }
+
+        function hideCardBubble() {
+            if (cardBubble) cardBubble.classList.remove('show');
+        }
+
+        const fivepCard = DOMUtils.safeQuerySelector('#fivepCard');
+        if (fivepCard) {
+            fivepCard.addEventListener('mouseenter', () => showCardBubble('Espacio destinado a las 5P', fivepCard));
+            fivepCard.addEventListener('mouseleave', hideCardBubble);
+        }
+
         const epdotFooter = DOMUtils.safeQuerySelector('#fiveepdotFooter');
         const epdotImgs = DOMUtils.safeQuerySelectorAll('#fiveepdotCard img');
         epdotImgs.forEach(img => {
@@ -744,6 +768,12 @@ document.addEventListener('DOMContentLoaded', async () => {
                 }
             });
         });
+
+        const fiveepdotCard = DOMUtils.safeQuerySelector('#fiveepdotCard');
+        if (fiveepdotCard) {
+            fiveepdotCard.addEventListener('mouseenter', () => showCardBubble('Cinco Ejes del PDOT', fiveepdotCard));
+            fiveepdotCard.addEventListener('mouseleave', hideCardBubble);
+        }
 
     } catch (error) {
         ErrorUtils.handleError(error, 'Inicialización del Sistema');


### PR DESCRIPTION
## Summary
- show bubble tooltip when hovering 5P and 5E PDOT cards
- animate labels by updating their text on image click

## Testing
- `node tests/test-chart-manager.js && node tests/test-csv-parser.js && node tests/test-filter-manager.js`

------
https://chatgpt.com/codex/tasks/task_e_68484b43310c8330a0bc11eff8438c00