### PR TITLE
Enhance fivep cards

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -299,10 +299,20 @@ body {
     margin-bottom: 0.5rem;
 }
 
-.fivep-images img {
+.fivep-item {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.fivep-item img {
     width: 64px;
     height: 48px;
     cursor: pointer;
+}
+
+.component-info-btn {
+    margin-top: 0.25rem;
 }
 
 /* 5E PDOT container */

--- a/index.html
+++ b/index.html
@@ -137,11 +137,26 @@
 
             <div class="stat-card" id="fivepCard" title="Espacio destinado a las 5P">
                 <div class="fivep-images">
-                    <img src="img/p1.png" alt="Personas" data-label="Personas">
-                    <img src="img/p2.png" alt="Paz" data-label="Paz">
-                    <img src="img/p3.png" alt="Pactos/Alianzas" data-label="Pactos/Alianzas">
-                    <img src="img/p4.png" alt="Planeta" data-label="Planeta">
-                    <img src="img/p5.png" alt="Prosperidad" data-label="Prosperidad">
+                    <div class="fivep-item">
+                        <img src="img/p1.png" alt="Personas" data-label="Personas">
+                        <button class="info-btn component-info-btn" type="button" aria-label="Más información">+</button>
+                    </div>
+                    <div class="fivep-item">
+                        <img src="img/p2.png" alt="Paz" data-label="Paz">
+                        <button class="info-btn component-info-btn" type="button" aria-label="Más información">+</button>
+                    </div>
+                    <div class="fivep-item">
+                        <img src="img/p3.png" alt="Pactos/Alianzas" data-label="Pactos/Alianzas">
+                        <button class="info-btn component-info-btn" type="button" aria-label="Más información">+</button>
+                    </div>
+                    <div class="fivep-item">
+                        <img src="img/p4.png" alt="Planeta" data-label="Planeta">
+                        <button class="info-btn component-info-btn" type="button" aria-label="Más información">+</button>
+                    </div>
+                    <div class="fivep-item">
+                        <img src="img/p5.png" alt="Prosperidad" data-label="Prosperidad">
+                        <button class="info-btn component-info-btn" type="button" aria-label="Más información">+</button>
+                    </div>
                 </div>
                 <div class="stat-footer" id="fivepFooter"></div>
             </div>

--- a/js/componentInfo.js
+++ b/js/componentInfo.js
@@ -3,14 +3,16 @@
 // Muestra información adicional sobre los componentes
 
 document.addEventListener('DOMContentLoaded', () => {
-  const infoBtn = document.getElementById('componentInfoBtn');
+  const infoBtns = document.querySelectorAll('#componentInfoBtn, .component-info-btn');
   const overlay = document.getElementById('componentInfoOverlay');
   const closeBtn = document.getElementById('componentInfoClose');
 
-  if (!infoBtn || !overlay || !closeBtn) return;
+  if (!overlay || !closeBtn || infoBtns.length === 0) return;
 
-  infoBtn.addEventListener('click', () => {
-    overlay.style.display = 'flex';
+  infoBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      overlay.style.display = 'flex';
+    });
   });
 
   closeBtn.addEventListener('click', () => {

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -736,16 +736,19 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         const cardBubble = DOMUtils.safeQuerySelector('#card-bubble');
 
-        function showCardBubble(message, targetEl) {
-            if (!cardBubble || !targetEl) return;
+        function showCardBubble(message) {
+            if (!cardBubble) return;
             cardBubble.textContent = message;
+            cardBubble.classList.add('show');
+        }
+
+        function moveCardBubble(evt) {
+            if (!cardBubble) return;
             const containerRect = cardBubble.parentElement.getBoundingClientRect();
-            const targetRect = targetEl.getBoundingClientRect();
-            const left = targetRect.left - containerRect.left + targetRect.width / 2;
-            const top = targetRect.top - containerRect.top;
+            const left = evt.clientX - containerRect.left + 10;
+            const top = evt.clientY - containerRect.top + 10;
             cardBubble.style.left = `${left}px`;
             cardBubble.style.top = `${top}px`;
-            cardBubble.classList.add('show');
         }
 
         function hideCardBubble() {
@@ -754,8 +757,16 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         const fivepCard = DOMUtils.safeQuerySelector('#fivepCard');
         if (fivepCard) {
-            fivepCard.addEventListener('mouseenter', () => showCardBubble('Espacio destinado a las 5P', fivepCard));
-            fivepCard.addEventListener('mouseleave', hideCardBubble);
+            const moveHandler = evt => moveCardBubble(evt);
+            fivepCard.addEventListener('mouseenter', evt => {
+                showCardBubble('Espacio destinado a las 5P');
+                moveCardBubble(evt);
+                fivepCard.addEventListener('mousemove', moveHandler);
+            });
+            fivepCard.addEventListener('mouseleave', () => {
+                hideCardBubble();
+                fivepCard.removeEventListener('mousemove', moveHandler);
+            });
         }
 
         const epdotFooter = DOMUtils.safeQuerySelector('#fiveepdotFooter');
@@ -771,8 +782,16 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         const fiveepdotCard = DOMUtils.safeQuerySelector('#fiveepdotCard');
         if (fiveepdotCard) {
-            fiveepdotCard.addEventListener('mouseenter', () => showCardBubble('Cinco Ejes del PDOT', fiveepdotCard));
-            fiveepdotCard.addEventListener('mouseleave', hideCardBubble);
+            const moveEpdotHandler = evt => moveCardBubble(evt);
+            fiveepdotCard.addEventListener('mouseenter', evt => {
+                showCardBubble('Cinco Ejes del PDOT');
+                moveCardBubble(evt);
+                fiveepdotCard.addEventListener('mousemove', moveEpdotHandler);
+            });
+            fiveepdotCard.addEventListener('mouseleave', () => {
+                hideCardBubble();
+                fiveepdotCard.removeEventListener('mousemove', moveEpdotHandler);
+            });
         }
 
     } catch (error) {


### PR DESCRIPTION
## Summary
- show component info overlay from multiple info buttons
- add info button below each image in the fivep card
- style new info buttons
- make card info bubble follow the mouse

## Testing
- `node tests/test-csv-parser.js`
- `node tests/test-chart-manager.js`
- `node tests/test-filter-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_68484db5b7188330a59077325f00ddcb