### PR TITLE
Remove card tooltips and adjust bubble position

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -807,3 +807,11 @@ body {
     border-style: solid;
     border-color: var(--white) transparent transparent transparent;
 }
+
+#card-bubble {
+    transform: translateY(-10px);
+}
+
+#card-bubble.show {
+    transform: translateY(-20px);
+}

--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
         <section class="stats-grid" role="region" aria-labelledby="stats-title">
             <h2 id="stats-title" class="sr-only">Estadísticas Generales</h2>
 
-            <div class="stat-card" id="fivepCard" title="Espacio destinado a las 5P">
+            <div class="stat-card" id="fivepCard">
                 <div class="fivep-images">
                     <div class="fivep-item">
                         <img src="img/p1.png" alt="Personas" data-label="Personas">
@@ -161,7 +161,7 @@
                 <div class="stat-footer" id="fivepFooter"></div>
             </div>
 
-            <div class="stat-card" id="fiveepdotCard" title="Cinco Ejes del PDOT">
+            <div class="stat-card" id="fiveepdotCard">
                 <div class="epdot-images">
                     <img src="img/5e1.png" alt="Manabí Vivo-Sostenible" data-label="Manabí Vivo-Sostenible">
                     <img src="img/5e2.png" alt="Manabí Integrado" data-label="Manabí Integrado">

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -744,8 +744,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         function moveCardBubble(evt) {
             if (!cardBubble) return;
-            const left = evt.pageX + 10;
-            const top = evt.pageY + 10;
+            const left = evt.pageX + 15;
+            const top = evt.pageY - cardBubble.offsetHeight / 2;
             cardBubble.style.left = `${left}px`;
             cardBubble.style.top = `${top}px`;
         }


### PR DESCRIPTION
## Summary
- remove `title` attributes from fivepCard and fiveepdotCard
- tweak bubble placement script so it appears right of the cursor
- override CSS transforms for `#card-bubble`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68485609d3848330acb56f7b43c16fb3