### PR TITLE
Improve responsive styles

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -507,7 +507,17 @@ body {
 }
 
 /* Responsive Design */
-@media (max-width: 768px) {
+@media (max-width: 1199.98px) {
+    .header-emblem { height: 60px; }
+}
+@media (max-width: 991.98px) {
+    .dashboard-layout { flex-direction: column; }
+    .ods-panel { width: 100%; top: auto; position: relative; }
+    .ods-grid { grid-template-columns: repeat(auto-fit, minmax(60px, 1fr)); }
+    .header-right { position: static; transform: none; margin-top: var(--spacing-sm); }
+}
+
+@media (max-width: 767.98px) {
     .container {
         padding: 1rem;
     }
@@ -548,6 +558,11 @@ body {
         right: 10px;
         max-width: none;
     }
+}
+@media (max-width: 575.98px) {
+    .header h1 { font-size: 1.5rem; }
+    .header-subtitle { font-size: 1rem; }
+    .header-emblem { height: 50px; }
 }
 
 /* Keyboard Navigation */

--- a/pb.html
+++ b/pb.html
@@ -108,6 +108,11 @@
       max-height: 90%;
       text-align: center;
     }
+    @media (max-width: 575.98px) {
+      .ring { width: 120px; height: 120px; }
+      .value { font-size: 1.5rem; }
+      #dashboard { padding: 1rem; }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add multiple breakpoints to dashboard styles
- adjust header and layout styles for tablet and mobile
- tweak pb loader screen for small devices

## Testing
- `node tests/test-csv-parser.js`
- `node tests/test-chart-manager.js`
- `node tests/test-filter-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_68485ae0c474833097ecee3f53d3c7a5