### PR TITLE
Implement FiveP filters

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -311,6 +311,22 @@ body {
     cursor: pointer;
 }
 
+.fivep-item img.encendido {
+    border: 3px solid var(--primary-blue);
+    box-sizing: border-box;
+    filter: none;
+}
+
+.fivep-item img.apagado {
+    border: 3px solid transparent;
+    box-sizing: border-box;
+    filter: grayscale(100%) brightness(80%);
+}
+
+.fivep-item img.dimmed {
+    filter: grayscale(60%) brightness(85%);
+}
+
 .component-info-btn {
     margin-top: 0.25rem;
 }

--- a/index.html
+++ b/index.html
@@ -344,6 +344,7 @@
     <script src="js/chartManager.js"></script>
     <script src="js/filterManager.js"></script>
     <script src="js/odsPanel.js"></script>
+    <script src="js/fivepPanel.js"></script>
     <script src="js/dashboard.js"></script>
     <script src="js/componentInfo.js"></script>
     <script src="js/silbi.js"></script>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -225,6 +225,11 @@ class Dashboard {
             if (window.ODSPanel) {
                 ODSPanel.init(this.state.data, this.filterManager);
             }
+
+            // Inicializar panel 5P
+            if (window.FivePPanel) {
+                FivePPanel.init(this.state.data, this.filterManager);
+            }
             
             // Actualizar dashboard inicial
             this.updateDashboard();
@@ -256,6 +261,11 @@ class Dashboard {
             // Resaltar ODS relacionados
             if (window.ODSPanel) {
                 ODSPanel.highlightForData(data);
+            }
+
+            // Resaltar 5P relacionados
+            if (window.FivePPanel) {
+                FivePPanel.highlightForData(data);
             }
             
             // Anunciar cambios para accesibilidad
@@ -723,16 +733,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Hacer la instancia disponible globalmente para debugging
         window.dashboard = dashboardInstance;
 
-        const footer = DOMUtils.safeQuerySelector('#fivepFooter');
-        const imgs = DOMUtils.safeQuerySelectorAll('#fivepCard img');
-        imgs.forEach(img => {
-            img.addEventListener('click', () => {
-                const label = img.getAttribute('data-label') || img.alt || '';
-                if (footer) {
-                    footer.textContent = label;
-                }
-            });
-        });
+
 
         const cardBubble = DOMUtils.safeQuerySelector('#card-bubble');
 

--- a/js/filterManager.js
+++ b/js/filterManager.js
@@ -9,7 +9,8 @@ class FilterManager {
             component: '',
             direction: '',
             search: '',
-            ods: ''
+            ods: '',
+            fivep: ''
         };
 
         this.datalistOptions = {
@@ -304,6 +305,14 @@ class FilterManager {
                     }
                 }
                 if (!hasODS) return false;
+            }
+
+            // Filtro 5P
+            if (filters.fivep && filters.fivep !== '') {
+                const pVal = filters.fivep.toLowerCase();
+                const p1 = DataUtils.getFieldValue(item, '5P1', '').toLowerCase();
+                const p2 = DataUtils.getFieldValue(item, '5P2', '').toLowerCase();
+                if (p1 !== pVal && p2 !== pVal) return false;
             }
 
 

--- a/js/fivepPanel.js
+++ b/js/fivepPanel.js
@@ -1,0 +1,98 @@
+const FivePPanel = {
+  init(data, filterManager = window.filterManagerInstance) {
+    this.data = data || [];
+    this.filterManager = filterManager;
+    this.images = Array.from(document.querySelectorAll('#fivepCard img'));
+    this.footerEl = document.getElementById('fivepFooter');
+    this.activeP = null;
+
+    this.images.forEach(img => {
+      img.addEventListener('click', () => {
+        const label = img.getAttribute('data-label') || img.alt || '';
+        if (this.footerEl) {
+          this.footerEl.textContent = label;
+        }
+        this.toggleP(label);
+      });
+    });
+
+    this.highlightForData(this.data);
+  },
+
+  extractPSet(dataset) {
+    const set = new Set();
+    dataset.forEach(ind => {
+      const p1 = DataUtils.getFieldValue(ind, '5P1', '').trim();
+      const p2 = DataUtils.getFieldValue(ind, '5P2', '').trim();
+      if (p1) set.add(p1);
+      if (p2) set.add(p2);
+    });
+    return set;
+  },
+
+  highlightForData(dataset) {
+    const set = this.extractPSet(dataset);
+    this.images.forEach(img => {
+      const label = img.getAttribute('data-label') || img.alt || '';
+      if (set.has(label)) {
+        img.classList.add('encendido');
+        img.classList.remove('apagado');
+      } else {
+        img.classList.remove('encendido');
+        img.classList.add('apagado');
+      }
+      if (this.activeP === label) {
+        img.classList.add('encendido');
+      } else if (this.activeP) {
+        img.classList.add('dimmed');
+      } else {
+        img.classList.remove('dimmed');
+      }
+    });
+
+    if (this.activeP && !set.has(this.activeP)) {
+      const pToClear = this.activeP;
+      this.activeP = null;
+      setTimeout(() => {
+        if (this.filterManager) {
+          this.filterManager.handleFilterChange('fivep', '');
+        }
+        if (this.footerEl) {
+          this.footerEl.textContent = pToClear;
+        }
+      }, 0);
+    }
+  },
+
+  toggleP(label) {
+    if (this.activeP === label) {
+      this.activeP = null;
+      if (this.filterManager) {
+        this.filterManager.handleFilterChange('fivep', '');
+      }
+    } else {
+      this.activeP = label;
+      if (this.filterManager) {
+        this.filterManager.handleFilterChange('fivep', label);
+      }
+    }
+    this.updateSelectedStyles();
+  },
+
+  updateSelectedStyles() {
+    this.images.forEach(img => {
+      const label = img.getAttribute('data-label') || img.alt || '';
+      if (this.activeP === label) {
+        img.classList.add('encendido');
+        img.classList.remove('apagado');
+        img.classList.remove('dimmed');
+      } else if (this.activeP) {
+        img.classList.add('dimmed');
+      } else {
+        img.classList.remove('dimmed');
+      }
+    });
+  }
+};
+
+window.FivePPanel = FivePPanel;


### PR DESCRIPTION
## Summary
- add script fivepPanel.js
- highlight 5P icons based on data
- filter data by 5P selections
- wire fivep panel into dashboard initialization and updates
- style fivep icons for on/off states

## Testing
- `node tests/test-csv-parser.js`
- `node tests/test-chart-manager.js`
- `node tests/test-filter-manager.js`

------
https://chatgpt.com/codex/tasks/task_e_684860ae47308330a8f0e345e952bf96