### PR TITLE
Update info popups and 5P card styling

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -306,8 +306,8 @@ body {
 }
 
 .fivep-item img {
-    width: 64px;
-    height: 48px;
+    width: 50px;
+    height: 50px;
     cursor: pointer;
 }
 
@@ -327,8 +327,19 @@ body {
     filter: grayscale(60%) brightness(85%);
 }
 
-.component-info-btn {
+.info-btn.component-info-btn {
     margin-top: 0.25rem;
+    width: 24px;
+    height: 24px;
+    background: var(--primary-blue);
+    color: var(--white);
+    border: none;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1rem;
+    cursor: pointer;
 }
 
 /* 5E PDOT container */

--- a/index.html
+++ b/index.html
@@ -113,14 +113,22 @@
                 </div>
 
                 <div class="filter-group">
-                    <label class="filter-label" for="direction-filter"><i class="fas fa-sitemap"></i> Direcciones</label>
+                    <label class="filter-label" for="direction-filter"><i class="fas fa-sitemap"></i> Direcciones
+                        <button id="directionInfoBtn" class="info-btn" type="button" aria-label="Más información">
+                            <i class="fas fa-info-circle"></i>
+                        </button>
+                    </label>
                     <input class="filter-input" id="direction-filter" list="direction-options" placeholder="Todas las direcciones" aria-describedby="direction-help">
                     <datalist id="direction-options"></datalist>
                     <div id="direction-help" class="sr-only">Selecciona una dirección para filtrar los indicadores</div>
                 </div>
 
                 <div class="filter-group">
-                    <label class="filter-label" for="theme-filter"><i class="fas fa-folder-open"></i> Registros Administrativos</label>
+                    <label class="filter-label" for="theme-filter"><i class="fas fa-folder-open"></i> Registros Administrativos
+                        <button id="themeInfoBtn" class="info-btn" type="button" aria-label="Más información">
+                            <i class="fas fa-info-circle"></i>
+                        </button>
+                    </label>
                     <input class="filter-input" id="theme-filter" list="theme-options" placeholder="Todos los RA" aria-describedby="theme-help">
                     <datalist id="theme-options"></datalist>
                     <div id="theme-help" class="sr-only">Selecciona un registro administrativo para filtrar los indicadores</div>
@@ -319,6 +327,32 @@
             <p><strong>Atención Ciudadana:</strong> Nodo que concentrará toda la información relacionada con las actividades y medios para facilitar el ejercicio de derechos ciudadanos: protección de grupos de atención prioritaria, seguridad y temas de cooperación internacional.</p>
             <p><strong>Administrativo Financiero:</strong> Nodo que concentrará toda la información Administrativa Financiera institucional.</p>
             <p><strong>Institucional:</strong> Nodo que concentrará toda la información derivada de la Gestión Interna y Externa de la Institución y que incluye el Marco Regulatorio Institucional.</p>
+        </div>
+    </div>
+
+    <div id="directionInfoOverlay" class="info-overlay" aria-modal="true" role="dialog" aria-labelledby="directionInfoTitle">
+        <div class="info-content">
+            <button id="directionInfoClose" class="info-close" aria-label="Cerrar">×</button>
+            <div class="info-header">
+                <div class="info-logo">
+                    <img src="img/silbico.png" alt="SILBico">
+                </div>
+                <h2 id="directionInfoTitle">Direcciones</h2>
+            </div>
+            <p>Direcciones: Se enlistan todas las direcciones del GADPM que contribuyen a cada componente.</p>
+        </div>
+    </div>
+
+    <div id="themeInfoOverlay" class="info-overlay" aria-modal="true" role="dialog" aria-labelledby="themeInfoTitle">
+        <div class="info-content">
+            <button id="themeInfoClose" class="info-close" aria-label="Cerrar">×</button>
+            <div class="info-header">
+                <div class="info-logo">
+                    <img src="img/silbico.png" alt="SILBico">
+                </div>
+                <h2 id="themeInfoTitle">Registros Administrativos</h2>
+            </div>
+            <p>Registros Administrativos: Fuente de Información oficial del SIL que contiene la mayor desagregación posible de las intervenciones ejecutadas, así como su territorialización, para el cálculo del indicador.</p>
         </div>
     </div>
 

--- a/js/componentInfo.js
+++ b/js/componentInfo.js
@@ -3,19 +3,27 @@
 // Muestra información adicional sobre los componentes
 
 document.addEventListener('DOMContentLoaded', () => {
-  const infoBtns = document.querySelectorAll('#componentInfoBtn, .component-info-btn');
-  const overlay = document.getElementById('componentInfoOverlay');
-  const closeBtn = document.getElementById('componentInfoClose');
+  const configs = [
+    { btn: '#componentInfoBtn, .component-info-btn', overlay: 'componentInfoOverlay', close: 'componentInfoClose' },
+    { btn: '#directionInfoBtn', overlay: 'directionInfoOverlay', close: 'directionInfoClose' },
+    { btn: '#themeInfoBtn', overlay: 'themeInfoOverlay', close: 'themeInfoClose' }
+  ];
 
-  if (!overlay || !closeBtn || infoBtns.length === 0) return;
+  configs.forEach(cfg => {
+    const buttons = document.querySelectorAll(cfg.btn);
+    const overlay = document.getElementById(cfg.overlay);
+    const closeBtn = document.getElementById(cfg.close);
 
-  infoBtns.forEach(btn => {
-    btn.addEventListener('click', () => {
-      overlay.style.display = 'flex';
+    if (!overlay || !closeBtn || buttons.length === 0) return;
+
+    buttons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        overlay.style.display = 'flex';
+      });
     });
-  });
 
-  closeBtn.addEventListener('click', () => {
-    overlay.style.display = 'none';
+    closeBtn.addEventListener('click', () => {
+      overlay.style.display = 'none';
+    });
   });
 });

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -769,7 +769,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (fivepCard) {
             const moveHandler = evt => moveCardBubble(evt);
             fivepCard.addEventListener('mouseenter', evt => {
-                showCardBubble('Espacio destinado a las 5P', true);
+                showCardBubble('5P dimensiones Agenda 2030', true);
                 moveCardBubble(evt);
                 fivepCard.addEventListener('mousemove', moveHandler);
             });


### PR DESCRIPTION
## Summary
- add info buttons for direction and theme filters
- add overlays for new help buttons
- show correct bubble text for fivep panel
- set fivep images to 50x50
- style plus buttons with blue circle
- support multiple info overlays

## Testing
- `node tests/test-chart-manager.js`
- `node tests/test-csv-parser.js`
- `node tests/test-filter-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_684a18bdaed08330a31c87898c864a20