### PR TITLE
Update ODS sidebar styles and accessibility

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -554,8 +554,16 @@ body {
     .header-emblem { height: 60px; }
 }
 @media (max-width: 991.98px) {
-    .dashboard-layout { flex-direction: column; }
-    .ods-panel { width: 100%; top: auto; position: relative; }
+    .dashboard-layout {
+        flex-direction: column;
+        gap: var(--spacing-md);
+    }
+    .ods-panel {
+        width: 100%;
+        position: relative;
+        top: auto;
+        padding: var(--spacing-md);
+    }
     .ods-grid { grid-template-columns: repeat(auto-fit, minmax(60px, 1fr)); }
     .header-right { position: static; transform: none; margin-top: var(--spacing-sm); }
 }
@@ -876,4 +884,22 @@ body {
 
 #card-bubble.show {
     transform: translateY(-20px);
+}
+
+@media (max-width: 575.98px) {
+    .ods-panel {
+        padding: var(--spacing-sm);
+    }
+    .ods-grid {
+        grid-template-columns: repeat(auto-fit, minmax(50px, 1fr));
+        gap: var(--spacing-xs);
+    }
+    .ods-item {
+        width: 50px;
+        height: 50px;
+    }
+    .ods-info {
+        margin-top: var(--spacing-sm);
+        font-size: var(--font-size-xs);
+    }
 }

--- a/index.html
+++ b/index.html
@@ -68,24 +68,24 @@
         <div class="dashboard-layout">
             <aside class="ods-panel" aria-labelledby="ods-panel-title">
                 <h2 id="ods-panel-title">Articulación con los ODS</h2>
-                <div class="ods-grid">
-                    <div class="ods-item" data-num="1"><img src="img/ods1.png" alt="ODS 1"></div>
-                    <div class="ods-item" data-num="2"><img src="img/ods2.png" alt="ODS 2"></div>
-                    <div class="ods-item" data-num="3"><img src="img/ods3.png" alt="ODS 3"></div>
-                    <div class="ods-item" data-num="4"><img src="img/ods4.png" alt="ODS 4"></div>
-                    <div class="ods-item" data-num="5"><img src="img/ods5.png" alt="ODS 5"></div>
-                    <div class="ods-item" data-num="6"><img src="img/ods6.png" alt="ODS 6"></div>
-                    <div class="ods-item" data-num="7"><img src="img/ods7.png" alt="ODS 7"></div>
-                    <div class="ods-item" data-num="8"><img src="img/ods8.png" alt="ODS 8"></div>
-                    <div class="ods-item" data-num="9"><img src="img/ods9.png" alt="ODS 9"></div>
-                    <div class="ods-item" data-num="10"><img src="img/ods10.png" alt="ODS 10"></div>
-                    <div class="ods-item" data-num="11"><img src="img/ods11.png" alt="ODS 11"></div>
-                    <div class="ods-item" data-num="12"><img src="img/ods12.png" alt="ODS 12"></div>
-                    <div class="ods-item" data-num="13"><img src="img/ods13.png" alt="ODS 13"></div>
-                    <div class="ods-item" data-num="14"><img src="img/ods14.png" alt="ODS 14"></div>
-                    <div class="ods-item" data-num="15"><img src="img/ods15.png" alt="ODS 15"></div>
-                    <div class="ods-item" data-num="16"><img src="img/ods16.png" alt="ODS 16"></div>
-                    <div class="ods-item" data-num="17"><img src="img/ods17.png" alt="ODS 17"></div>
+                <div class="ods-grid" role="grid">
+                    <div class="ods-item" data-num="1" role="gridcell" tabindex="0" aria-label="ODS 1"><img src="img/ods1.png" alt="ODS 1"></div>
+                    <div class="ods-item" data-num="2" role="gridcell" tabindex="0" aria-label="ODS 2"><img src="img/ods2.png" alt="ODS 2"></div>
+                    <div class="ods-item" data-num="3" role="gridcell" tabindex="0" aria-label="ODS 3"><img src="img/ods3.png" alt="ODS 3"></div>
+                    <div class="ods-item" data-num="4" role="gridcell" tabindex="0" aria-label="ODS 4"><img src="img/ods4.png" alt="ODS 4"></div>
+                    <div class="ods-item" data-num="5" role="gridcell" tabindex="0" aria-label="ODS 5"><img src="img/ods5.png" alt="ODS 5"></div>
+                    <div class="ods-item" data-num="6" role="gridcell" tabindex="0" aria-label="ODS 6"><img src="img/ods6.png" alt="ODS 6"></div>
+                    <div class="ods-item" data-num="7" role="gridcell" tabindex="0" aria-label="ODS 7"><img src="img/ods7.png" alt="ODS 7"></div>
+                    <div class="ods-item" data-num="8" role="gridcell" tabindex="0" aria-label="ODS 8"><img src="img/ods8.png" alt="ODS 8"></div>
+                    <div class="ods-item" data-num="9" role="gridcell" tabindex="0" aria-label="ODS 9"><img src="img/ods9.png" alt="ODS 9"></div>
+                    <div class="ods-item" data-num="10" role="gridcell" tabindex="0" aria-label="ODS 10"><img src="img/ods10.png" alt="ODS 10"></div>
+                    <div class="ods-item" data-num="11" role="gridcell" tabindex="0" aria-label="ODS 11"><img src="img/ods11.png" alt="ODS 11"></div>
+                    <div class="ods-item" data-num="12" role="gridcell" tabindex="0" aria-label="ODS 12"><img src="img/ods12.png" alt="ODS 12"></div>
+                    <div class="ods-item" data-num="13" role="gridcell" tabindex="0" aria-label="ODS 13"><img src="img/ods13.png" alt="ODS 13"></div>
+                    <div class="ods-item" data-num="14" role="gridcell" tabindex="0" aria-label="ODS 14"><img src="img/ods14.png" alt="ODS 14"></div>
+                    <div class="ods-item" data-num="15" role="gridcell" tabindex="0" aria-label="ODS 15"><img src="img/ods15.png" alt="ODS 15"></div>
+                    <div class="ods-item" data-num="16" role="gridcell" tabindex="0" aria-label="ODS 16"><img src="img/ods16.png" alt="ODS 16"></div>
+                    <div class="ods-item" data-num="17" role="gridcell" tabindex="0" aria-label="ODS 17"><img src="img/ods17.png" alt="ODS 17"></div>
                 </div>
                 <div class="ods-info">
                     <h3 id="ods-title"></h3>


### PR DESCRIPTION
## Summary
- tweak responsive layout for the dashboard
- add small‑screen media query for the ODS sidebar
- enhance ODS grid markup with aria roles and labels

## Testing
- `node tests/test-csv-parser.js`
- `node tests/test-filter-manager.js`
- `node tests/test-chart-manager.js`


------
https://chatgpt.com/codex/tasks/task_e_684a232852708330bc3bdfed1fb24b6e