### PR TITLE
Fix responsive manager initialization

### DIFF
--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -752,7 +752,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     try {
         if (window.ResponsiveManager) {
-            ResponsiveManager.init();
+            window.ResponsiveManager.init();
         }
         dashboardInstance = new Dashboard();
 


### PR DESCRIPTION
## Summary
- call the correct instance of `ResponsiveManager` on DOMContentLoaded

## Testing
- `node tests/test-csv-parser.js`
- `node tests/test-filter-manager.js`

------
https://chatgpt.com/codex/tasks/task_e_684a3dc33bf08330bf935ae29be1582e